### PR TITLE
fix: restore standalone CLI lock closure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9371,6 +9371,18 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/@treeseed/sdk/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@treeseed/ui": {
       "version": "0.12.18-dev.feature-content-repository-authority.20260811T113238Z",
       "resolved": "git+ssh://git@github.com/treeseed-ai/ui.git#d622525826d4222ced78e7748880750f6c1377bb",


### PR DESCRIPTION
## Summary

- add the missing nested `semver@7.8.5` lock record required by the exact SDK staging dependency
- preserve all unrelated lock metadata byte-for-byte
- restore a path to a standalone `platform workset` operator closure without Market workspace links

## Evidence

- base: `3b0483a487c837b7d5d838db739387a36f10e1b2`
- `corepack npm ci --ignore-scripts --no-audit --no-fund`: passed (1,202 packages)
- lock diff: 12 added lines only
- `git diff --check`: passed

## Pending acceptance

Full local scripted install/build/verification is pending guest disk-reserve recovery. The ignore-scripts closure cannot execute because the Git-sourced SDK build artifacts are intentionally absent. Hosted CI is expected to perform the authoritative scripted clean install; this PR must remain draft and unmerged until local clean acceptance and exact artifact/read-back evidence also pass.

This is a bounded Gate 0 bootstrap repair. It does not migrate CLI workflows or grant release authority.