### PR TITLE
Enable Market-disabled local Platform bootstrap

### DIFF
--- a/src/cli/handlers/accounts/auth-login.ts
+++ b/src/cli/handlers/accounts/auth-login.ts
@@ -5,6 +5,7 @@ import {
 import { KeyAgentError } from '@treeseed/sdk/workflow-support';
 import { guidedResult } from '../utilities/utils.js';
 import { createMarketClientForInvocation, marketAuthRoot } from '../content/market-utils.js';
+import { MarketIntegrationDisabledError } from '../content/support/market-mode.js';
 
 function sleep(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -109,6 +110,15 @@ export const handleAuthLogin: CommandHandler = async (invocation, context) => {
 			stderr: ['Treeseed API login expired before approval completed.'],
 		};
 	} catch (error) {
+		if (error instanceof MarketIntegrationDisabledError) {
+			return guidedResult({
+				command: 'auth:login',
+				summary: error.message,
+				report: { code: error.code },
+				exitCode: 1,
+				stderr: [error.message],
+			});
+		}
 		if (error instanceof KeyAgentError) {
 			return {
 				exitCode: 1,

--- a/src/cli/handlers/content/market-utils.ts
+++ b/src/cli/handlers/content/market-utils.ts
@@ -8,6 +8,7 @@ import {
 } from '@treeseed/sdk/market-client';
 import { findNearestRoot } from '@treeseed/sdk/workflow-support';
 import type { CommandContext, ParsedInvocation } from '../../types.js';
+import { assertMarketIntegrationEnabled } from './support/market-mode.js';
 
 export function marketAuthRoot(context: CommandContext) {
 	return findNearestRoot(context.cwd) ?? resolve(context.env.HOME || homedir());
@@ -27,6 +28,7 @@ export function localAcceptanceAdminToken(env: NodeJS.ProcessEnv) {
 
 export function createMarketClientForInvocation(invocation: ParsedInvocation, context: CommandContext, options: { requireAuth?: boolean; allowLocalAcceptanceAdmin?: boolean } = {}) {
 	const profile = resolveMarketProfile(marketSelector(invocation));
+	assertMarketIntegrationEnabled(context.cwd, profile.id);
 	const session = resolveMarketSession(marketAuthRoot(context), profile.id);
 	const localAccessToken = options.allowLocalAcceptanceAdmin && profile.id === 'local'
 		? localAcceptanceAdminToken(context.env)

--- a/src/cli/handlers/content/market.ts
+++ b/src/cli/handlers/content/market.ts
@@ -7,9 +7,23 @@ import {
 import type { CommandHandler } from '../../types.js';
 import { guidedResult } from '../utilities/utils.js';
 import { createMarketClientForInvocation, formatMarketProfile } from './market-utils.js';
+import { resolveMarketIntegrationMode } from './support/market-mode.js';
 
 export const handleMarket: CommandHandler = async (invocation, context) => {
 	const action = invocation.positionals[0] ?? 'list';
+	const mode = resolveMarketIntegrationMode(context.cwd);
+	if (!mode.enabled) {
+		const inspectOnly = action === 'list' || action === 'status';
+		return guidedResult({
+			command: 'market',
+			summary: 'Market integration is disabled for this local development workspace.',
+			facts: [{ label: 'Enabled', value: false }, { label: 'Configured profile', value: mode.profile }],
+			nextSteps: ['Use the local customer-owned control plane for development.', 'Enable Market explicitly only after its service is available.'],
+			report: { code: 'market_integration_disabled', enabled: false, profile: mode.profile },
+			exitCode: inspectOnly ? 0 : 1,
+			...(inspectOnly ? {} : { stderr: ['Market mutations are unavailable while Market integration is disabled.'] }),
+		});
+	}
 	if (action === 'list') {
 		const state = loadMarketRegistryState();
 		return guidedResult({

--- a/src/cli/handlers/content/support/market-mode.ts
+++ b/src/cli/handlers/content/support/market-mode.ts
@@ -10,11 +10,17 @@ function record(value: unknown): JsonRecord {
 
 function siteManifestPath(cwd: string) {
 	let current = resolve(cwd);
+	let fallback: string | null = null;
 	while (true) {
 		const candidate = resolve(current, 'treeseed.site.yaml');
-		if (existsSync(candidate)) return candidate;
+		if (existsSync(candidate)) {
+			fallback ??= candidate;
+			const document = record(parse(readFileSync(candidate, 'utf8')));
+			const localDevelopment = record(record(document.development).local);
+			if (typeof localDevelopment.marketConnectivity === 'string') return candidate;
+		}
 		const parent = dirname(current);
-		if (parent === current) return null;
+		if (parent === current) return fallback;
 		current = parent;
 	}
 }
@@ -22,6 +28,7 @@ function siteManifestPath(cwd: string) {
 export type MarketIntegrationMode = {
 	enabled: boolean;
 	manifestPath: string | null;
+	workspaceRoot: string;
 	profile: string;
 	inventorySource: 'api' | 'seed';
 	seedPath: string;
@@ -38,7 +45,7 @@ export class MarketIntegrationDisabledError extends Error {
 
 export function resolveMarketIntegrationMode(cwd: string): MarketIntegrationMode {
 	const manifestPath = siteManifestPath(cwd);
-	if (!manifestPath) return { enabled: true, manifestPath: null, profile: 'treeseed', inventorySource: 'api', seedPath: 'seeds/treeseed.yaml' };
+	if (!manifestPath) return { enabled: true, manifestPath: null, workspaceRoot: resolve(cwd), profile: 'treeseed', inventorySource: 'api', seedPath: 'seeds/treeseed.yaml' };
 	const document = record(parse(readFileSync(manifestPath, 'utf8')));
 	const market = record(document.market);
 	const localDevelopment = record(record(document.development).local);
@@ -53,6 +60,7 @@ export function resolveMarketIntegrationMode(cwd: string): MarketIntegrationMode
 	return {
 		enabled: marketConnectivity !== 'disabled' && market.enabled !== false,
 		manifestPath,
+		workspaceRoot: dirname(manifestPath),
 		profile: typeof market.profile === 'string' && market.profile.trim() ? market.profile.trim() : 'treeseed',
 		inventorySource,
 		seedPath: typeof inventory.path === 'string' && inventory.path.trim() ? inventory.path.trim() : 'seeds/treeseed.yaml',

--- a/src/cli/handlers/content/support/market-mode.ts
+++ b/src/cli/handlers/content/support/market-mode.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { parse } from 'yaml';
+
+type JsonRecord = Record<string, unknown>;
+
+function record(value: unknown): JsonRecord {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value as JsonRecord : {};
+}
+
+function siteManifestPath(cwd: string) {
+	let current = resolve(cwd);
+	while (true) {
+		const candidate = resolve(current, 'treeseed.site.yaml');
+		if (existsSync(candidate)) return candidate;
+		const parent = dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+}
+
+export type MarketIntegrationMode = {
+	enabled: boolean;
+	manifestPath: string | null;
+	profile: string;
+	inventorySource: 'api' | 'seed';
+	seedPath: string;
+};
+
+export class MarketIntegrationDisabledError extends Error {
+	readonly code = 'market_integration_disabled';
+
+	constructor() {
+		super('Market integration is disabled for this local development workspace. Use the local control plane or enable Market explicitly after it is available.');
+		this.name = 'MarketIntegrationDisabledError';
+	}
+}
+
+export function resolveMarketIntegrationMode(cwd: string): MarketIntegrationMode {
+	const manifestPath = siteManifestPath(cwd);
+	if (!manifestPath) return { enabled: true, manifestPath: null, profile: 'treeseed', inventorySource: 'api', seedPath: 'seeds/treeseed.yaml' };
+	const document = record(parse(readFileSync(manifestPath, 'utf8')));
+	const market = record(document.market);
+	const localDevelopment = record(record(document.development).local);
+	const inventory = record(localDevelopment.inventory);
+	const marketConnectivity = typeof localDevelopment.marketConnectivity === 'string'
+		? localDevelopment.marketConnectivity.trim().toLowerCase()
+		: null;
+	if (marketConnectivity && marketConnectivity !== 'enabled' && marketConnectivity !== 'disabled') {
+		throw new Error(`Unsupported development.local.marketConnectivity value ${String(localDevelopment.marketConnectivity)}.`);
+	}
+	const inventorySource = inventory.source === 'seed' ? 'seed' : 'api';
+	return {
+		enabled: marketConnectivity !== 'disabled' && market.enabled !== false,
+		manifestPath,
+		profile: typeof market.profile === 'string' && market.profile.trim() ? market.profile.trim() : 'treeseed',
+		inventorySource,
+		seedPath: typeof inventory.path === 'string' && inventory.path.trim() ? inventory.path.trim() : 'seeds/treeseed.yaml',
+	};
+}
+
+export function assertMarketIntegrationEnabled(cwd: string, profileId: string) {
+	if (profileId === 'treeseed' && !resolveMarketIntegrationMode(cwd).enabled) {
+		throw new MarketIntegrationDisabledError();
+	}
+}

--- a/src/cli/handlers/runtime/platform-workset-inventory.ts
+++ b/src/cli/handlers/runtime/platform-workset-inventory.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { PlatformWorksetInventoryRepository } from '@treeseed/sdk';
 import type { MarketClient } from '@treeseed/sdk/market-client';
-import { parse } from 'yaml';
+import { formatSeedDiagnostics, validateSeedSource } from '@treeseed/sdk/seeds';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -74,38 +74,44 @@ function localRepository(projectId: string, repository: JsonRecord): PlatformWor
 	const name = text(repository.name);
 	if (!owner || !name || /^(market|market-api)$/u.test(name) || name.endsWith('-content') || name === 'platform') return null;
 	const path = text(repository.submodulePath) ?? text(repository.checkoutPath);
+	const gitUrl = text(repository.gitUrl) ?? text(repository.url);
 	const policy = record(repository.repositoryPolicy);
 	const branch = text(repository.currentBranch) ?? text(policy.stagingBranch) ?? text(repository.defaultBranch);
 	if (!path || !branch) throw new Error(`Local Platform inventory repository ${owner}/${name} is missing a checkout path or branch.`);
-	return { projectId, role, path, repository: `${owner}/${name}`, branch };
+	return { projectId, role, path, repository: gitUrl ?? `${owner}/${name}`, branch };
 }
 
-function localTeamId(resources: JsonRecord, selector: string) {
+function localTeam(resources: JsonRecord, selector: string) {
 	const teams = Array.isArray(resources.teams) ? resources.teams.map(record) : [];
 	const team = teams.find((candidate) => matchesTeam(candidate, selector)
 		|| text(candidate.key)?.toLowerCase() === `team:${selector.toLowerCase()}`);
 	if (!team) throw new Error(`Local Platform inventory does not declare team ${selector}.`);
-	return text(team.key) ?? text(team.id) ?? text(team.slug) ?? selector;
+	return { id: text(team.key) ?? text(team.id) ?? text(team.slug) ?? selector, identities: new Set([team.key, team.id, team.slug].map(text).filter(Boolean)) };
 }
 
 export function loadLocalPlatformWorksetInventory(root: string, teamSelector: string, seedPath = 'seeds/treeseed.yaml') {
-	const document = record(parse(readFileSync(resolve(root, seedPath), 'utf8')));
+	const validated = validateSeedSource(readFileSync(resolve(root, seedPath), 'utf8'));
+	if (!validated.ok || !validated.manifest) throw new Error(`Local Platform inventory seed is invalid:\n${formatSeedDiagnostics(validated.diagnostics).join('\n')}`);
+	const document = record(validated.manifest);
 	const resources = record(document.resources);
-	const teamId = localTeamId(resources, teamSelector);
-	const projects = Array.isArray(resources.projects) ? resources.projects.map(record) : [];
+	const team = localTeam(resources, teamSelector);
+	const projects = (Array.isArray(resources.projects) ? resources.projects.map(record) : [])
+		.filter((project) => team.identities.has(text(project.team)));
+	const selectedProjectIds = new Set(projects.map((project) => text(project.key) ?? text(project.id) ?? text(project.slug)).filter(Boolean));
 	const projectRepositories = projects.map((project) => {
 		const projectId = text(project.key) ?? text(project.id) ?? text(project.slug);
 		if (!projectId) throw new Error('Local Platform inventory contains a project without an identity.');
 		return localRepository(projectId, record(project.repository));
 	});
 	const supportRepositories = (Array.isArray(resources.hubRepositories) ? resources.hubRepositories.map(record) : [])
+		.filter((repository) => selectedProjectIds.has(text(repository.project)))
 		.map((repository) => {
 			const projectId = text(repository.project);
 			if (!projectId) throw new Error('Local Platform inventory contains a support repository without a project identity.');
 			return localRepository(projectId, repository);
 		});
 	return {
-		teamId,
+		teamId: team.id,
 		inventory: [...projectRepositories, ...supportRepositories]
 			.filter((entry): entry is PlatformWorksetInventoryRepository => Boolean(entry)),
 		inventorySource: 'local-seed' as const,

--- a/src/cli/handlers/runtime/platform-workset-inventory.ts
+++ b/src/cli/handlers/runtime/platform-workset-inventory.ts
@@ -1,5 +1,8 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { PlatformWorksetInventoryRepository } from '@treeseed/sdk';
 import type { MarketClient } from '@treeseed/sdk/market-client';
+import { parse } from 'yaml';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -62,4 +65,50 @@ export async function loadPlatformWorksetInventory(client: MarketClient, teamSel
 		return repositories.map((repository) => materializableRepository(project, repository)).filter((entry): entry is PlatformWorksetInventoryRepository => Boolean(entry));
 	});
 	return { teamId: response.payload?.teamId ?? teamId, inventory };
+}
+
+function localRepository(projectId: string, repository: JsonRecord): PlatformWorksetInventoryRepository | null {
+	const role = text(repository.role);
+	if (role !== 'primary' && role !== 'fixture') return null;
+	const owner = text(repository.owner);
+	const name = text(repository.name);
+	if (!owner || !name || /^(market|market-api)$/u.test(name) || name.endsWith('-content') || name === 'platform') return null;
+	const path = text(repository.submodulePath) ?? text(repository.checkoutPath);
+	const policy = record(repository.repositoryPolicy);
+	const branch = text(repository.currentBranch) ?? text(policy.stagingBranch) ?? text(repository.defaultBranch);
+	if (!path || !branch) throw new Error(`Local Platform inventory repository ${owner}/${name} is missing a checkout path or branch.`);
+	return { projectId, role, path, repository: `${owner}/${name}`, branch };
+}
+
+function localTeamId(resources: JsonRecord, selector: string) {
+	const teams = Array.isArray(resources.teams) ? resources.teams.map(record) : [];
+	const team = teams.find((candidate) => matchesTeam(candidate, selector)
+		|| text(candidate.key)?.toLowerCase() === `team:${selector.toLowerCase()}`);
+	if (!team) throw new Error(`Local Platform inventory does not declare team ${selector}.`);
+	return text(team.key) ?? text(team.id) ?? text(team.slug) ?? selector;
+}
+
+export function loadLocalPlatformWorksetInventory(root: string, teamSelector: string, seedPath = 'seeds/treeseed.yaml') {
+	const document = record(parse(readFileSync(resolve(root, seedPath), 'utf8')));
+	const resources = record(document.resources);
+	const teamId = localTeamId(resources, teamSelector);
+	const projects = Array.isArray(resources.projects) ? resources.projects.map(record) : [];
+	const projectRepositories = projects.map((project) => {
+		const projectId = text(project.key) ?? text(project.id) ?? text(project.slug);
+		if (!projectId) throw new Error('Local Platform inventory contains a project without an identity.');
+		return localRepository(projectId, record(project.repository));
+	});
+	const supportRepositories = (Array.isArray(resources.hubRepositories) ? resources.hubRepositories.map(record) : [])
+		.map((repository) => {
+			const projectId = text(repository.project);
+			if (!projectId) throw new Error('Local Platform inventory contains a support repository without a project identity.');
+			return localRepository(projectId, repository);
+		});
+	return {
+		teamId,
+		inventory: [...projectRepositories, ...supportRepositories]
+			.filter((entry): entry is PlatformWorksetInventoryRepository => Boolean(entry)),
+		inventorySource: 'local-seed' as const,
+		seedPath,
+	};
 }

--- a/src/cli/handlers/runtime/run.ts
+++ b/src/cli/handlers/runtime/run.ts
@@ -15,9 +15,10 @@ import { handleUpdate } from '../workspace-lifecycle/update.js';
 import { fail } from '../utilities/utils.js';
 import { platformSupervisorPaths, processIsAlive, readPlatformSupervisor, type PlatformSupervisorState } from './platform-supervisor-state.js';
 import { runPlatformMutationWhenAvailable } from './platform-supervisor-workflows.js';
-import { loadPlatformWorksetInventory } from './platform-workset-inventory.js';
+import { loadLocalPlatformWorksetInventory, loadPlatformWorksetInventory } from './platform-workset-inventory.js';
 import { inspectPlatformRepositories } from './platform-repository-status.js';
 import { createMarketClientForInvocation } from '../content/market-utils.js';
+import { resolveMarketIntegrationMode } from '../content/support/market-mode.js';
 
 type RunState = {
 	schemaVersion: 1;
@@ -345,14 +346,21 @@ export const handlePlatform: CommandHandler = async (invocation, context) => {
 		if (invocation.args.apply === true && invocation.args.yes !== true) return fail('Applying a Platform workset requires --apply --yes.');
 		if (branch && !assignmentId) return fail('A writable Platform workset branch requires --assignment <acting-assignment-id>.');
 		try {
-			const { client } = createMarketClientForInvocation(invocation, context, { requireAuth: true, allowLocalAcceptanceAdmin: true });
-			const { teamId, inventory } = await loadPlatformWorksetInventory(client, teamSelector);
-			const authority = assignmentId ? await governedWorksetAuthority(client, teamId, assignmentId) : null;
+			const marketMode = resolveMarketIntegrationMode(context.cwd);
+			if (!marketMode.enabled && assignmentId) return fail('Writable workset custody requires the local control plane; start it and use --market local before requesting an assignment branch.');
+			const client = marketMode.enabled
+				? createMarketClientForInvocation(invocation, context, { requireAuth: true, allowLocalAcceptanceAdmin: true }).client
+				: null;
+			const loaded = client
+				? await loadPlatformWorksetInventory(client, teamSelector)
+				: loadLocalPlatformWorksetInventory(context.cwd, teamSelector, marketMode.seedPath);
+			const { teamId, inventory } = loaded;
+			const authority = assignmentId && client ? await governedWorksetAuthority(client, teamId, assignmentId) : null;
 			const input = { root: context.cwd, teamId, inventory, branch, authority, env: context.env };
 			const report = invocation.args.apply === true
 				? applyPlatformWorkset(input)
 				: planPlatformWorkset(input);
-			return { exitCode: report.summary.blocked ? 1 : 0, report: { command: 'platform workset', ok: report.summary.blocked === 0, executionMode: invocation.args.apply === true ? 'apply' : 'plan', ...report } };
+			return { exitCode: report.summary.blocked ? 1 : 0, report: { command: 'platform workset', ok: report.summary.blocked === 0, executionMode: invocation.args.apply === true ? 'apply' : 'plan', inventorySource: 'inventorySource' in loaded ? loaded.inventorySource : 'api', ...report } };
 		} catch (error) {
 			return fail(error instanceof Error ? error.message : String(error));
 		}
@@ -367,9 +375,11 @@ export const handlePlatform: CommandHandler = async (invocation, context) => {
 	if (action === 'status') {
 		try {
 			const teamSelector = typeof invocation.args.team === 'string' ? invocation.args.team : context.env.TREESEED_TEAM_ID?.trim() || 'treeseed';
-			const { client } = createMarketClientForInvocation(invocation, context, { requireAuth: true, allowLocalAcceptanceAdmin: true });
-			const inventory = await loadPlatformWorksetInventory(client, teamSelector);
-			repositories = { teamId: inventory.teamId, items: inspectPlatformRepositories(context.cwd, inventory.inventory) };
+			const marketMode = resolveMarketIntegrationMode(context.cwd);
+			const inventory = marketMode.enabled
+				? await loadPlatformWorksetInventory(createMarketClientForInvocation(invocation, context, { requireAuth: true, allowLocalAcceptanceAdmin: true }).client, teamSelector)
+				: loadLocalPlatformWorksetInventory(context.cwd, teamSelector, marketMode.seedPath);
+			repositories = { teamId: inventory.teamId, inventorySource: 'inventorySource' in inventory ? inventory.inventorySource : 'api', items: inspectPlatformRepositories(context.cwd, inventory.inventory) };
 		} catch (error) {
 			repositories = { unavailable: true, error: error instanceof Error ? error.message : String(error) };
 		}

--- a/src/cli/handlers/runtime/run.ts
+++ b/src/cli/handlers/runtime/run.ts
@@ -17,7 +17,7 @@ import { platformSupervisorPaths, processIsAlive, readPlatformSupervisor, type P
 import { runPlatformMutationWhenAvailable } from './platform-supervisor-workflows.js';
 import { loadLocalPlatformWorksetInventory, loadPlatformWorksetInventory } from './platform-workset-inventory.js';
 import { inspectPlatformRepositories } from './platform-repository-status.js';
-import { createMarketClientForInvocation } from '../content/market-utils.js';
+import { createMarketClientForInvocation, marketSelector } from '../content/market-utils.js';
 import { resolveMarketIntegrationMode } from '../content/support/market-mode.js';
 
 type RunState = {
@@ -347,16 +347,22 @@ export const handlePlatform: CommandHandler = async (invocation, context) => {
 		if (branch && !assignmentId) return fail('A writable Platform workset branch requires --assignment <acting-assignment-id>.');
 		try {
 			const marketMode = resolveMarketIntegrationMode(context.cwd);
-			if (!marketMode.enabled && assignmentId) return fail('Writable workset custody requires the local control plane; start it and use --market local before requesting an assignment branch.');
-			const client = marketMode.enabled
+			if (assignmentId && !marketMode.enabled && marketSelector(invocation) !== 'local') {
+				const message = 'Writable workset custody requires the local control plane; start it and use --market local before requesting an assignment branch.';
+				return { exitCode: 1, stderr: [message], report: { command: 'platform workset', ok: false, code: 'control_plane_required_for_writable_workset', error: message } };
+			}
+			const inventoryClient = marketMode.inventorySource === 'api'
 				? createMarketClientForInvocation(invocation, context, { requireAuth: true, allowLocalAcceptanceAdmin: true }).client
 				: null;
-			const loaded = client
-				? await loadPlatformWorksetInventory(client, teamSelector)
-				: loadLocalPlatformWorksetInventory(context.cwd, teamSelector, marketMode.seedPath);
+			const authorityClient = assignmentId
+				? createMarketClientForInvocation(invocation, context, { requireAuth: true, allowLocalAcceptanceAdmin: true }).client
+				: null;
+			const loaded = inventoryClient
+				? await loadPlatformWorksetInventory(inventoryClient, teamSelector)
+				: loadLocalPlatformWorksetInventory(marketMode.workspaceRoot, teamSelector, marketMode.seedPath);
 			const { teamId, inventory } = loaded;
-			const authority = assignmentId && client ? await governedWorksetAuthority(client, teamId, assignmentId) : null;
-			const input = { root: context.cwd, teamId, inventory, branch, authority, env: context.env };
+			const authority = assignmentId && authorityClient ? await governedWorksetAuthority(authorityClient, teamId, assignmentId) : null;
+			const input = { root: marketMode.workspaceRoot, teamId, inventory, branch, authority, env: context.env };
 			const report = invocation.args.apply === true
 				? applyPlatformWorkset(input)
 				: planPlatformWorkset(input);
@@ -376,10 +382,10 @@ export const handlePlatform: CommandHandler = async (invocation, context) => {
 		try {
 			const teamSelector = typeof invocation.args.team === 'string' ? invocation.args.team : context.env.TREESEED_TEAM_ID?.trim() || 'treeseed';
 			const marketMode = resolveMarketIntegrationMode(context.cwd);
-			const inventory = marketMode.enabled
+			const inventory = marketMode.inventorySource === 'api'
 				? await loadPlatformWorksetInventory(createMarketClientForInvocation(invocation, context, { requireAuth: true, allowLocalAcceptanceAdmin: true }).client, teamSelector)
-				: loadLocalPlatformWorksetInventory(context.cwd, teamSelector, marketMode.seedPath);
-			repositories = { teamId: inventory.teamId, inventorySource: 'inventorySource' in inventory ? inventory.inventorySource : 'api', items: inspectPlatformRepositories(context.cwd, inventory.inventory) };
+				: loadLocalPlatformWorksetInventory(marketMode.workspaceRoot, teamSelector, marketMode.seedPath);
+			repositories = { teamId: inventory.teamId, inventorySource: 'inventorySource' in inventory ? inventory.inventorySource : 'api', items: inspectPlatformRepositories(marketMode.workspaceRoot, inventory.inventory) };
 		} catch (error) {
 			repositories = { unavailable: true, error: error instanceof Error ? error.message : String(error) };
 		}

--- a/src/cli/handlers/seeds/seed.ts
+++ b/src/cli/handlers/seeds/seed.ts
@@ -44,6 +44,10 @@ export function localRuntimePlan(planned: SeedPlan, applied: SeedPlan): SeedPlan
 	return { ...applied, runtime: planned.runtime };
 }
 
+export function localSeedApplyPreference(marketEnabled: boolean, hasAccessToken: boolean): 'direct' | 'api' {
+	return !marketEnabled || !hasAccessToken ? 'direct' : 'api';
+}
+
 function remoteSeedResult(payload: Record<string, unknown>, command: string, exitCode = 0) {
 	const plan = planFromRemotePayload(payload);
 	const result = payload.result && typeof payload.result === 'object' ? payload.result as Record<string, unknown> : null;
@@ -340,11 +344,9 @@ export const handleSeed: CommandHandler = async (invocation, context) => {
 		}
 		const localModule = await loadLocalSeedModule(context.cwd);
 		const marketMode = resolveMarketIntegrationMode(context.cwd);
-		const runner = !marketMode.enabled
+		const runner = localSeedApplyPreference(marketMode.enabled, Boolean(localAuth.session.accessToken)) === 'direct'
 			? localModule.applyLocalSeedFromCli ?? localModule.applyLocalSeedViaApiFromCli
-			: localAuth.session.accessToken
-			? localModule.applyLocalSeedViaApiFromCli ?? localModule.applyLocalSeedFromCli
-			: localModule.applyLocalSeedFromCli ?? localModule.applyLocalSeedViaApiFromCli;
+			: localModule.applyLocalSeedViaApiFromCli ?? localModule.applyLocalSeedFromCli;
 		if (typeof runner !== 'function') {
 			throw new Error('Local seed apply service is not available in this market project.');
 		}

--- a/src/cli/handlers/seeds/seed.ts
+++ b/src/cli/handlers/seeds/seed.ts
@@ -4,6 +4,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { formatSeedDiagnostics, formatSeedPlan, loadAndPlanSeed, reconcileLocalSeedRuntime, type SeedPlan } from '@treeseed/sdk/seeds';
 import { MarketClientError } from '@treeseed/sdk/market-client';
 import { createMarketClientForInvocation, marketSelector } from '../content/market-utils.js';
+import { resolveMarketIntegrationMode } from '../content/support/market-mode.js';
 import { loadLocalSeedModule, requireLocalSeedSession } from '../accounts/seed-session.js';
 import { handleSeedRepositories } from './seed-repositories.js';
 import { handleSeedContentRepositories } from './migrations/seed-content-repositories.js';
@@ -338,7 +339,10 @@ export const handleSeed: CommandHandler = async (invocation, context) => {
 			return remoteSeedError(error, 'seed');
 		}
 		const localModule = await loadLocalSeedModule(context.cwd);
-		const runner = localAuth.session.accessToken
+		const marketMode = resolveMarketIntegrationMode(context.cwd);
+		const runner = !marketMode.enabled
+			? localModule.applyLocalSeedFromCli ?? localModule.applyLocalSeedViaApiFromCli
+			: localAuth.session.accessToken
 			? localModule.applyLocalSeedViaApiFromCli ?? localModule.applyLocalSeedFromCli
 			: localModule.applyLocalSeedFromCli ?? localModule.applyLocalSeedViaApiFromCli;
 		if (typeof runner !== 'function') {

--- a/src/cli/operations/operations-platform-run.ts
+++ b/src/cli/operations/operations-platform-run.ts
@@ -39,11 +39,11 @@ export const platformRunOperationSpecs: OperationSpec[] = [
 	},
 	{
 		id: 'local.platform', name: 'platform', aliases: [], group: 'Local Development', provider: 'default', related: ['run', 'status'],
-		summary: 'Materialize, inspect, or stop the local TreeSeed platform.', description: 'Materialize an exact ephemeral repository workset or expose status, logs, and stop diagnostics for the platform managed by trsd run.',
+		summary: 'Materialize, inspect, or stop the local TreeSeed platform.', description: 'Materialize an exact ephemeral repository workset from local seed inventory or expose status, logs, and stop diagnostics for the platform managed by trsd run.',
 		usage: 'trsd platform init|status|logs|pause|stop|workset [directory] [--plan|--apply --yes] [--team <team>] [--json]', arguments: [{ name: 'action', description: 'init, status, logs, pause, stop, or workset', required: true }, { name: 'directory', description: 'Platform clone target for init.', required: false }],
 		options: [
 			{ name: 'plan', flags: '--plan', description: 'Preview exact workset materialization without mutation.', kind: 'boolean' },
-			{ name: 'apply', flags: '--apply', description: 'Materialize missing repositories from the authenticated team project inventory.', kind: 'boolean' },
+			{ name: 'apply', flags: '--apply', description: 'Materialize missing repositories from the configured local seed or authenticated control-plane inventory.', kind: 'boolean' },
 			{ name: 'yes', flags: '--yes', description: 'Confirm workset materialization.', kind: 'boolean' },
 			{ name: 'team', flags: '--team <team>', description: 'Team ID or slug whose project inventory defines the workset.', kind: 'string' },
 			{ name: 'repository', flags: '--repository <owner/repository>', description: 'Canonical live Platform repository (treeseed-ai/platform).', kind: 'string' },
@@ -58,10 +58,10 @@ export const platformRunOperationSpecs: OperationSpec[] = [
 		help: {
 			workflowPosition: 'inspect local platform',
 			longSummary: [
-				'Platform reads the authenticated live team project inventory, observes exact repository branch heads, materializes independent ephemeral checkouts, and exposes runtime controls.',
+				'Platform reads the configured local seed when Market connectivity is disabled, or the authenticated control-plane inventory when enabled. It observes exact repository branch heads, materializes independent ephemeral checkouts, and exposes runtime controls.',
 			],
 			whenToUse: [
-				'Use `workset` from a clean Platform clone to assemble integrated development repositories without gitlinks. Use the other actions to inspect or stop the local runtime.',
+				'Use `workset` from a clean Platform clone to assemble integrated development repositories without gitlinks. Read-only seed inventory requires no Market service or login. Use the other actions to inspect or stop the local runtime.',
 			],
 			beforeYouRun: [
 				'Run from the workspace that owns the local platform state. Workset apply requires `--apply --yes` and refuses dirty, divergent, or incorrectly sourced existing checkouts.',

--- a/tests/integration/runtime/platform-workset-inventory.test.ts
+++ b/tests/integration/runtime/platform-workset-inventory.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
 import test from 'node:test';
-import { loadPlatformWorksetInventory } from '../../../src/cli/handlers/runtime/platform-workset-inventory.ts';
+import { loadLocalPlatformWorksetInventory, loadPlatformWorksetInventory } from '../../../src/cli/handlers/runtime/platform-workset-inventory.ts';
 import { governedWorksetAuthority } from '../../../src/cli/handlers/runtime/run.ts';
 
 test('Platform workset resolves a team and selects only managed software and fixture repositories', async () => {
@@ -29,6 +32,45 @@ test('Platform workset resolves a team and selects only managed software and fix
 				{ projectId: 'project-platform', role: 'fixture', path: '.fixtures/treeseed-fixtures', repository: 'treeseed-ai/fixtures', branch: 'staging' },
 			],
 		});
+});
+
+test('Platform workset compiles local seed inventory without Market or content custody', () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-local-workset-'));
+	try {
+		mkdirSync(resolve(root, 'seeds'));
+		writeFileSync(resolve(root, 'seeds/treeseed.yaml'), `resources:
+  teams:
+    - key: team:treeseed
+      slug: treeseed
+  projects:
+    - key: project:treeseed/platform
+      repository: { role: primary, owner: treeseed-ai, name: platform, checkoutPath: ., defaultBranch: main }
+    - key: project:treeseed/api
+      repository: { role: primary, owner: treeseed-ai, name: api, checkoutPath: packages/api, defaultBranch: main, repositoryPolicy: { stagingBranch: staging } }
+    - key: project:treeseed/market
+      repository: { role: primary, owner: treeseed-ai, name: market, checkoutPath: packages/market, defaultBranch: main }
+    - key: project:treeseed/content
+      repository: { role: primary, owner: treeseed-ai, name: docs-content, checkoutPath: packages/docs-content, defaultBranch: main }
+  hubRepositories:
+    - project: project:treeseed/platform
+      role: fixture
+      owner: treeseed-ai
+      name: fixtures
+      submodulePath: .fixtures/treeseed-fixtures
+      currentBranch: staging
+`);
+		assert.deepEqual(loadLocalPlatformWorksetInventory(root, 'treeseed'), {
+			teamId: 'team:treeseed',
+			inventory: [
+				{ projectId: 'project:treeseed/api', role: 'primary', path: 'packages/api', repository: 'treeseed-ai/api', branch: 'staging' },
+				{ projectId: 'project:treeseed/platform', role: 'fixture', path: '.fixtures/treeseed-fixtures', repository: 'treeseed-ai/fixtures', branch: 'staging' },
+			],
+			inventorySource: 'local-seed',
+			seedPath: 'seeds/treeseed.yaml',
+		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
 });
 
 test('writable Platform workset custody is compiled only from a matching active acting assignment and plan',async () => {

--- a/tests/integration/runtime/platform-workset-inventory.test.ts
+++ b/tests/integration/runtime/platform-workset-inventory.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import test from 'node:test';
 import { loadLocalPlatformWorksetInventory, loadPlatformWorksetInventory } from '../../../src/cli/handlers/runtime/platform-workset-inventory.ts';
-import { governedWorksetAuthority } from '../../../src/cli/handlers/runtime/run.ts';
+import { governedWorksetAuthority, handlePlatform } from '../../../src/cli/handlers/runtime/run.ts';
+import { localSeedApplyPreference } from '../../../src/cli/handlers/seeds/seed.ts';
 
 test('Platform workset resolves a team and selects only managed software and fixture repositories', async () => {
 		const client = {
@@ -38,39 +39,58 @@ test('Platform workset compiles local seed inventory without Market or content c
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-local-workset-'));
 	try {
 		mkdirSync(resolve(root, 'seeds'));
-		writeFileSync(resolve(root, 'seeds/treeseed.yaml'), `resources:
-  teams:
-    - key: team:treeseed
-      slug: treeseed
-  projects:
-    - key: project:treeseed/platform
-      repository: { role: primary, owner: treeseed-ai, name: platform, checkoutPath: ., defaultBranch: main }
-    - key: project:treeseed/api
-      repository: { role: primary, owner: treeseed-ai, name: api, checkoutPath: packages/api, defaultBranch: main, repositoryPolicy: { stagingBranch: staging } }
-    - key: project:treeseed/market
-      repository: { role: primary, owner: treeseed-ai, name: market, checkoutPath: packages/market, defaultBranch: main }
-    - key: project:treeseed/content
-      repository: { role: primary, owner: treeseed-ai, name: docs-content, checkoutPath: packages/docs-content, defaultBranch: main }
-  hubRepositories:
-    - project: project:treeseed/platform
-      role: fixture
-      owner: treeseed-ai
-      name: fixtures
-      submodulePath: .fixtures/treeseed-fixtures
-      currentBranch: staging
-`);
+		const policy = { visibility: 'public', lifecycle: 'create-or-adopt', deletionPolicy: 'retain', defaultBranch: 'main', stagingBranch: 'staging', issues: true, actions: true, workflows: ['verify.yml'] };
+		const architecture = { topology: 'split_site_content', rootPath: '.', sitePath: 'docs', contentPath: 'src/content', contentRuntimeSource: 'r2_preview_overlay', localContentMaterialization: 'none', requiresLocalContentForCi: false, requiresLocalContentForDeploy: false, contentPublishTarget: { kind: 'cloudflare_r2', prefix: 'fixture' } };
+		const project = (team: string, slug: string, name = slug) => ({
+			key: `project:${team.split(':')[1]}/${slug}`, team, slug, name,
+			repository: { role: 'primary', provider: 'github', owner: 'treeseed-ai', name: slug, gitUrl: `https://github.com/treeseed-ai/${slug}.git`, defaultBranch: 'main', checkoutPath: slug === 'platform' ? '.' : `packages/${slug}`, repositoryPolicy: policy },
+			architecture,
+		});
+		writeFileSync(resolve(root, 'seeds/treeseed.yaml'), JSON.stringify({
+			name: 'treeseed', version: 1, defaultEnvironments: ['local'], environments: ['local'],
+			resources: {
+				teams: [
+					{ key: 'team:treeseed', slug: 'treeseed', name: 'treeseed', displayName: 'TreeSeed' },
+					{ key: 'team:other', slug: 'other', name: 'other', displayName: 'Other' },
+				],
+				projects: [project('team:treeseed', 'platform'), project('team:treeseed', 'api'), project('team:treeseed', 'market'), project('team:treeseed', 'docs-content'), project('team:other', 'other-package')],
+				hubRepositories: [{ key: 'repository:treeseed/fixtures', project: 'project:treeseed/platform', role: 'fixture', provider: 'github', owner: 'treeseed-ai', name: 'fixtures', gitUrl: 'https://github.com/treeseed-ai/fixtures.git', defaultBranch: 'main', currentBranch: 'staging', submodulePath: '.fixtures/treeseed-fixtures', status: 'active', repositoryPolicy: policy }],
+			},
+		}));
 		assert.deepEqual(loadLocalPlatformWorksetInventory(root, 'treeseed'), {
 			teamId: 'team:treeseed',
 			inventory: [
-				{ projectId: 'project:treeseed/api', role: 'primary', path: 'packages/api', repository: 'treeseed-ai/api', branch: 'staging' },
-				{ projectId: 'project:treeseed/platform', role: 'fixture', path: '.fixtures/treeseed-fixtures', repository: 'treeseed-ai/fixtures', branch: 'staging' },
+				{ projectId: 'project:treeseed/api', role: 'primary', path: 'packages/api', repository: 'https://github.com/treeseed-ai/api.git', branch: 'staging' },
+				{ projectId: 'project:treeseed/platform', role: 'fixture', path: '.fixtures/treeseed-fixtures', repository: 'https://github.com/treeseed-ai/fixtures.git', branch: 'staging' },
 			],
 			inventorySource: 'local-seed',
 			seedPath: 'seeds/treeseed.yaml',
 		});
+		mkdirSync(resolve(root, 'packages/nested'), { recursive: true });
+		assert.equal(loadLocalPlatformWorksetInventory(root, 'treeseed').inventory.length, 2);
 	} finally {
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+test('Market-disabled writable workset returns a stable local-control-plane requirement', async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-local-workset-authority-'));
+	try {
+		writeFileSync(resolve(root, 'treeseed.site.yaml'), 'market: { profile: treeseed }\ndevelopment: { local: { marketConnectivity: disabled, inventory: { source: seed } } }\n');
+		const result = await handlePlatform({ commandName: 'platform', args: { branch: 'codex/test', assignment: 'assignment-a' }, positionals: ['workset'], rawArgs: [] }, {
+			cwd: root, env: {}, outputFormat: 'json', write() {}, spawn: (() => { throw new Error('unexpected spawn'); }) as never,
+		});
+		assert.equal(result.exitCode, 1);
+		assert.equal(result.report?.code, 'control_plane_required_for_writable_workset');
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test('Market-disabled local seed apply prefers the direct store adapter', () => {
+	assert.equal(localSeedApplyPreference(false, true), 'direct');
+	assert.equal(localSeedApplyPreference(true, true), 'api');
+	assert.equal(localSeedApplyPreference(true, false), 'direct');
 });
 
 test('writable Platform workset custody is compiled only from a matching active acting assignment and plan',async () => {

--- a/tests/unit/runtime/market-mode.test.ts
+++ b/tests/unit/runtime/market-mode.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import test from 'node:test';
+import { handleMarket } from '../../../src/cli/handlers/content/market.ts';
 import {
 	assertMarketIntegrationEnabled,
 	MarketIntegrationDisabledError,
@@ -13,6 +14,7 @@ test('local development can disable Market while retaining its immutable profile
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-market-mode-'));
 	try {
 		mkdirSync(resolve(root, 'nested'));
+		writeFileSync(resolve(root, 'nested/treeseed.site.yaml'), 'market: { profile: treeseed }\n');
 		writeFileSync(resolve(root, 'treeseed.site.yaml'), `market: { profile: treeseed }
 development:
   local:
@@ -22,6 +24,7 @@ development:
 		assert.deepEqual(resolveMarketIntegrationMode(resolve(root, 'nested')), {
 			enabled: false,
 			manifestPath: resolve(root, 'treeseed.site.yaml'),
+			workspaceRoot: root,
 			profile: 'treeseed',
 			inventorySource: 'seed',
 			seedPath: 'seeds/local.yaml',
@@ -34,12 +37,32 @@ development:
 	}
 });
 
+test('Market status returns the stable disabled result without network access', async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-market-disabled-handler-'));
+	const originalFetch = globalThis.fetch;
+	let fetched = false;
+	try {
+		writeFileSync(resolve(root, 'treeseed.site.yaml'), 'market: { profile: treeseed }\ndevelopment: { local: { marketConnectivity: disabled } }\n');
+		globalThis.fetch = (async () => { fetched = true; throw new Error('unexpected fetch'); }) as typeof fetch;
+		const result = await handleMarket({ commandName: 'market', args: {}, positionals: ['status'], rawArgs: [] }, {
+			cwd: root, env: { HOME: resolve(root, 'missing-home') }, outputFormat: 'json', write() {}, spawn: (() => { throw new Error('unexpected spawn'); }) as never,
+		});
+		assert.equal(result.exitCode, 0);
+		assert.equal(result.report?.code, 'market_integration_disabled');
+		assert.equal(fetched, false);
+	} finally {
+		globalThis.fetch = originalFetch;
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test('Market remains enabled when no local policy is declared', () => {
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-market-mode-default-'));
 	try {
 		assert.deepEqual(resolveMarketIntegrationMode(root), {
 			enabled: true,
 			manifestPath: null,
+			workspaceRoot: root,
 			profile: 'treeseed',
 			inventorySource: 'api',
 			seedPath: 'seeds/treeseed.yaml',

--- a/tests/unit/runtime/market-mode.test.ts
+++ b/tests/unit/runtime/market-mode.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import {
+	assertMarketIntegrationEnabled,
+	MarketIntegrationDisabledError,
+	resolveMarketIntegrationMode,
+} from '../../../src/cli/handlers/content/support/market-mode.ts';
+
+test('local development can disable Market while retaining its immutable profile identity', () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-market-mode-'));
+	try {
+		mkdirSync(resolve(root, 'nested'));
+		writeFileSync(resolve(root, 'treeseed.site.yaml'), `market: { profile: treeseed }
+development:
+  local:
+    marketConnectivity: disabled
+    inventory: { source: seed, path: seeds/local.yaml }
+`);
+		assert.deepEqual(resolveMarketIntegrationMode(resolve(root, 'nested')), {
+			enabled: false,
+			manifestPath: resolve(root, 'treeseed.site.yaml'),
+			profile: 'treeseed',
+			inventorySource: 'seed',
+			seedPath: 'seeds/local.yaml',
+		});
+		assert.throws(() => assertMarketIntegrationEnabled(root, 'treeseed'), (error) =>
+			error instanceof MarketIntegrationDisabledError && error.code === 'market_integration_disabled');
+		assert.doesNotThrow(() => assertMarketIntegrationEnabled(root, 'local'));
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
+test('Market remains enabled when no local policy is declared', () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-market-mode-default-'));
+	try {
+		assert.deepEqual(resolveMarketIntegrationMode(root), {
+			enabled: true,
+			manifestPath: null,
+			profile: 'treeseed',
+			inventorySource: 'api',
+			seedPath: 'seeds/treeseed.yaml',
+		});
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## What changed

- add an explicit local Market-disabled policy reader
- make Market commands and central login fail before network access when disabled
- load read-only Platform worksets directly from the configured local seed
- preserve API-backed assignment authority for writable worksets
- prefer direct local seed application when Market connectivity is disabled
- validate and team-scope seed inventory, preserve explicit repository URLs, and resolve Platform policy from nested package invocations

## Why

The Platform development bootstrap could not run while the hosted/default Market was unavailable. Read-only repository materialization does not require Market authority, and the Platform seed already contains the provider-neutral repository inventory.

## Impact

Local-managed Platform workspaces can plan and materialize their exact read-only repository workset without Market or API login. Market identity remains configured, and writable custody continues to fail closed until the local control plane supplies assignment authority.

This removes the Market/control-plane service prerequisite. Repository fetches still use the configured swappable repository provider (currently GitHub); a digest-bound exact-commit local-mirror lock is a separate offline layer.

## Validation

- complete `verify:direct`: 237 tests passed at the initial head; corrected exact-head rerun pending
- packed-install CLI smoke passed
- tool-closure pack passed
- live Platform plan resolved exactly 13 permitted repositories
- live apply and replay returned 13 noops, zero blocked
- local seed apply/re-plan returned 29 unchanged, zero errors
- local API inventory exactly matched the 13 workset records
