### PR TITLE
feat: add project contribution authorization commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,6 +39,8 @@ Contributor mode (select one):
 
 <!-- Record exact commands, checks, contract/compatibility evidence, and results. -->
 
+- [ ] I ran the narrowest relevant package verification and documented any checks that could not be run.
+
 ## Risk and rollback
 
 <!-- Identify risks, migration effects, and an exact rollback/recovery path. -->
@@ -46,6 +48,25 @@ Contributor mode (select one):
 ## Completion summary
 
 <!-- Summarize the journey, final status, unresolved blockers, and next action. -->
+
+## Contribution grant (human action required)
+
+The accountable human must review [CONTRIBUTING.md](https://github.com/treeseed-ai/cli/blob/main/CONTRIBUTING.md) and check the affirmation below. Agents must leave it unchecked for the human.
+
+<!--
+An agent must not check this box. The human contributor or accountable human must
+read CONTRIBUTING.md and affirm the grant by checking it in the PR description.
+-->
+
+- [ ] I have read `CONTRIBUTING.md`, have the right to submit this contribution, and intentionally submit it for inclusion under the Apache License, Version 2.0, without additional terms or conditions, as described by Section 5.
+
+## Agent contribution attestation
+
+Governed agents must leave the human affirmation unchecked. TreeSeed populates the managed block below only when an active project authorization, assignment, agent, capacity provider, repository, base SHA, and head SHA all match. Agents cannot create or broaden that authorization.
+
+<!-- treeseed:contribution-attestation:start -->
+Pending — TreeSeed will replace this text for an authorized agent contribution.
+<!-- treeseed:contribution-attestation:end -->
 
 ## Submission checklist
 

--- a/.github/workflows/contributor-license.yml
+++ b/.github/workflows/contributor-license.yml
@@ -1,0 +1,65 @@
+name: Contributor License Grant
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  affirmation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify human grant or delegated agent attestation
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        with:
+          script: |
+            const { createHash, createPublicKey, verify } = require('node:crypto');
+            const pr = context.payload.pull_request;
+            const body = pr?.body ?? '';
+            const checked = (label) => body.split(/\r?\n/u).some((line) => line.trim() === `- [x] ${label}` || line.trim() === `- [X] ${label}`);
+            const humanMode = checked('Human-authored');
+            const agentMode = checked('Agent-assisted under human authority') || checked('Agent-authored under human authority');
+            const grant = 'I have read `CONTRIBUTING.md`, have the right to submit this contribution, and intentionally submit it for inclusion under the Apache License, Version 2.0, without additional terms or conditions, as described by Section 5.';
+            const humanGrant = checked(grant);
+            if (humanMode) {
+              if (agentMode) return core.setFailed('Select exactly one contributor mode.');
+              if (!humanGrant) return core.setFailed('Check the human Contribution grant affirmation before this contribution can be merged.');
+              return;
+            }
+            if (!agentMode) return core.setFailed('Select one contributor mode.');
+            if (humanGrant) return core.setFailed('An agent contribution must not check or claim the Human contribution affirmation.');
+            const start = '<!-- treeseed:contribution-attestation:start -->';
+            const end = '<!-- treeseed:contribution-attestation:end -->';
+            const block = body.slice(body.indexOf(start), body.indexOf(end));
+            const encoded = /```json treeseed-contribution-attestation\s+([\s\S]*?)\s+```/u.exec(block)?.[1];
+            if (!encoded) return core.setFailed('A managed TreeSeed agent contribution attestation is required.');
+            let bundle;
+            try { bundle = JSON.parse(encoded); } catch { return core.setFailed('The managed contribution attestation is invalid JSON.'); }
+            async function baseFile(path) {
+              const response = await github.rest.repos.getContent({ owner: context.repo.owner, repo: context.repo.repo, path, ref: pr.base.sha });
+              if (Array.isArray(response.data) || !response.data.content) throw new Error(`${path} is not a file.`);
+              return Buffer.from(response.data.content, response.data.encoding ?? 'base64').toString('utf8');
+            }
+            let policy, guidance;
+            try { policy = JSON.parse(await baseFile('.treeseed/contribution-policy.json')); guidance = await baseFile('AGENTS.md'); }
+            catch (error) { return core.setFailed(`The base branch has no trusted project contribution policy: ${error.message}`); }
+            if (!guidance.includes('delegated-project-authorization') || !guidance.includes('contribution_attestation')) return core.setFailed('Base AGENTS.md does not permit delegated contribution attestation.');
+            const authorization = bundle.authorization; const attestation = bundle.attestation;
+            if (JSON.stringify(authorization) !== JSON.stringify(policy.activeAuthorization)) return core.setFailed('The attestation authorization does not match the base branch project policy.');
+            const expectedRepo = { provider: 'github', owner: context.repo.owner, name: context.repo.repo };
+            const exact = attestation?.base?.sha === pr.base.sha && attestation?.head?.sha === pr.head.sha && attestation?.base?.branch === pr.base.ref && attestation?.head?.branch === pr.head.ref;
+            if (!exact) return core.setFailed('The agent contribution attestation is stale for the exact PR base or head.');
+            if (JSON.stringify(authorization?.repository) !== JSON.stringify(expectedRepo) || JSON.stringify(attestation?.repository) !== JSON.stringify(expectedRepo)) return core.setFailed('Repository authorization does not match this PR.');
+            if (authorization.status !== 'active' || !Number.isFinite(Date.parse(authorization.effectiveAt)) || Date.parse(authorization.effectiveAt) > Date.now() || (authorization.expiresAt && Date.parse(authorization.expiresAt) <= Date.now())) return core.setFailed('Project contribution authorization is inactive, not yet effective, or expired.');
+            if (!authorization.allowedActions.includes('populate_pr_attestation')) return core.setFailed('Project authorization does not permit PR attestation.');
+            if (!authorization.agentIds.includes(attestation.agentId) || !authorization.capacityProviderIds.includes(attestation.capacityProviderId) || !authorization.contributionModes.includes(attestation.mode) || !authorization.targetBranches.includes(pr.base.ref)) return core.setFailed('Agent, provider, contribution mode, or target branch is not authorized.');
+            if (attestation.authorization.id !== authorization.id || attestation.authorization.generation !== authorization.generation || attestation.authorization.digest !== authorization.grant.digest) return core.setFailed('Authorization generation or grant digest does not match.');
+            const canonical = (value) => Array.isArray(value) ? value.map(canonical) : value && typeof value === 'object' ? Object.fromEntries(Object.entries(value).sort(([a],[b]) => a.localeCompare(b)).map(([key,item]) => [key,canonical(item)])) : value;
+            const { receipt, ...payload } = attestation;
+            const bytes = Buffer.from(JSON.stringify(canonical({ ...payload, receipt: { keyId: receipt.keyId, algorithm: receipt.algorithm } })), 'utf8');
+            const digest = `sha256:${createHash('sha256').update(bytes).digest('base64url')}`;
+            if (digest !== receipt.payloadDigest || receipt.keyId !== authorization.receiptKey.keyId || receipt.algorithm !== 'Ed25519') return core.setFailed('Contribution receipt digest or key binding is invalid.');
+            if (!verify(null, bytes, createPublicKey({ key: authorization.receiptKey.publicKeyJwk, format: 'jwk' }), Buffer.from(receipt.signature, 'base64url'))) return core.setFailed('Contribution receipt signature is invalid.');

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# CLI agent contribution policy
+
+Agents may populate or update the managed **Agent contribution attestation** only when their definition enables `delegated-project-authorization`, their assignment and capacity grant include `contribution_attestation`, and TreeSeed provides a valid project authorization receipt bound to the exact repository, agent, capacity provider, assignment, base SHA, and head SHA.
+
+Agents must never check or edit the **Human contribution affirmation** and may not run contribution `apply`, `revoke`, or trusted-policy `project` actions. Those actions require an authenticated human team owner and explicit confirmation. Agents may use only `show` and `diagnose` until a scoped receipt is issued.
+
+Keep work scoped to this CLI repository and preserve local operation without a hosted Market dependency.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to TreeSeed CLI
+
+Human and governed-agent contributions use the same durable pull-request record. Select exactly one contributor mode and preserve the exact base/head refs, work authority, verification, commits, and completion summary.
+
+Human contributors must check the template affirmation themselves. Governed agents must leave it unchecked and may populate only the TreeSeed-managed attestation block when an active project authorization, assignment, agent, capacity provider, repository, base, and head all match.
+
+By intentionally submitting a Contribution for inclusion in this Apache-2.0 project, and unless you explicitly state otherwise, the Contribution is submitted under the Apache License, Version 2.0 without additional terms or conditions as described by Section 5. Review [the repository license](LICENSE) and the [official Apache License 2.0 text](https://www.apache.org/licenses/LICENSE-2.0) before affirming.
+
+Do not submit code, documentation, or other material you do not have the right to contribute. An agent cannot create, broaden, renew, revoke, or impersonate a human contribution authorization.

--- a/docs/src/content/agents/architect.mdx
+++ b/docs/src/content/agents/architect.mdx
@@ -15,6 +15,11 @@ groupIds:
   - agent
   - architecture
   - engineering-team
+contribution:
+  mode: delegated-project-authorization
+  mayPopulatePrAttestation: true
+  requiredCapability: contribution_attestation
+  requireExactHead: true
 identity:
   purpose: Defines the project architecture, objectives, standards, and decision-aligned knowledge structure.
   responsibilities:

--- a/docs/src/content/agents/engineer.mdx
+++ b/docs/src/content/agents/engineer.mdx
@@ -15,6 +15,11 @@ groupIds:
   - agent
   - engineering
   - engineering-team
+contribution:
+  mode: delegated-project-authorization
+  mayPopulatePrAttestation: true
+  requiredCapability: contribution_attestation
+  requireExactHead: true
 identity:
   purpose: Implements decision-scoped code and configuration changes without modifying tests.
   responsibilities:

--- a/docs/src/content/agents/releaser.mdx
+++ b/docs/src/content/agents/releaser.mdx
@@ -15,6 +15,11 @@ groupIds:
   - agent
   - engineering-team
   - release
+contribution:
+  mode: delegated-project-authorization
+  mayPopulatePrAttestation: true
+  requiredCapability: contribution_attestation
+  requireExactHead: true
 identity:
   purpose: Verifies staged changes and coordinates reliable release from staging through TreeSeed release operations.
   responsibilities:

--- a/docs/src/content/agents/reporter.mdx
+++ b/docs/src/content/agents/reporter.mdx
@@ -15,6 +15,11 @@ groupIds:
   - agent
   - engineering-team
   - reporting
+contribution:
+  mode: delegated-project-authorization
+  mayPopulatePrAttestation: true
+  requiredCapability: contribution_attestation
+  requireExactHead: true
 identity:
   purpose: Deterministically summarizes workdays, capacity, graph progress, blockers, tool telemetry, and outcomes.
   responsibilities:

--- a/docs/src/content/agents/researcher.mdx
+++ b/docs/src/content/agents/researcher.mdx
@@ -15,6 +15,11 @@ groupIds:
   - agent
   - engineering-team
   - research
+contribution:
+  mode: delegated-project-authorization
+  mayPopulatePrAttestation: true
+  requiredCapability: contribution_attestation
+  requireExactHead: true
 identity:
   purpose: Answers questions and improves project knowledge through TreeDX-backed research content.
   responsibilities:

--- a/docs/src/content/agents/reviewer.mdx
+++ b/docs/src/content/agents/reviewer.mdx
@@ -15,6 +15,11 @@ groupIds:
   - agent
   - engineering-team
   - review
+contribution:
+  mode: delegated-project-authorization
+  mayPopulatePrAttestation: true
+  requiredCapability: contribution_attestation
+  requireExactHead: true
 identity:
   purpose: Reviews knowledge, proposals, deliverables, and staged work for accuracy, clarity, and risk.
   responsibilities:

--- a/docs/src/content/agents/technical-writer.mdx
+++ b/docs/src/content/agents/technical-writer.mdx
@@ -15,6 +15,11 @@ groupIds:
   - agent
   - engineering-team
   - technical-writing
+contribution:
+  mode: delegated-project-authorization
+  mayPopulatePrAttestation: true
+  requiredCapability: contribution_attestation
+  requireExactHead: true
 identity:
   purpose: Maintains user, developer, and operator documentation for released and staged project capabilities.
   responsibilities:

--- a/docs/src/content/agents/tester.mdx
+++ b/docs/src/content/agents/tester.mdx
@@ -15,6 +15,11 @@ groupIds:
   - agent
   - engineering-team
   - testing
+contribution:
+  mode: delegated-project-authorization
+  mayPopulatePrAttestation: true
+  requiredCapability: contribution_attestation
+  requireExactHead: true
 identity:
   purpose: Creates tests before implementation and verifies behavior without modifying implementation code.
   responsibilities:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@treeseed/agent": "github:treeseed-ai/agent#6e1a7345e6ec1c75d8020ce4c08c68bea7ad99e7",
         "@treeseed/core": "github:treeseed-ai/core#32a5c1eeb5f6e5e655910f679c684bf4f2cad244",
-        "@treeseed/sdk": "github:treeseed-ai/sdk#c12d422516a9de3a501b5c48c9d15363550add0c",
+        "@treeseed/sdk": "github:treeseed-ai/sdk#2412568c6b311978c896f283b6af845f4e65b928",
         "@treeseed/ui": "github:treeseed-ai/ui#d622525826d4222ced78e7748880750f6c1377bb",
         "ink": "^7.0.0",
         "react": "^19.2.5",
@@ -8849,7 +8849,7 @@
     },
     "node_modules/@treeseed/sdk": {
       "version": "0.12.63-dev.fix-sdk-package-lock-integrity.20260818T124913Z",
-      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#c12d422516a9de3a501b5c48c9d15363550add0c",
+      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#2412568c6b311978c896f283b6af845f4e65b928",
       "integrity": "sha512-WEuDEN/5h/DJWdul+QeYl9K2Tpc70LWdvdo8zxuktat5f9Vi67OFd424v94fTok9SDrIAKzS00pzchIdecUmsQ==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@treeseed/agent": "github:treeseed-ai/agent#6e1a7345e6ec1c75d8020ce4c08c68bea7ad99e7",
         "@treeseed/core": "github:treeseed-ai/core#32a5c1eeb5f6e5e655910f679c684bf4f2cad244",
-        "@treeseed/sdk": "github:treeseed-ai/sdk#8cef5fb4beea8751eaece91cdfe62de007930360",
+        "@treeseed/sdk": "github:treeseed-ai/sdk#5db07e79bbd32bcd753d7600d15b7412357fc8c5",
         "@treeseed/ui": "github:treeseed-ai/ui#d622525826d4222ced78e7748880750f6c1377bb",
         "ink": "^7.0.0",
         "react": "^19.2.5",
@@ -8849,7 +8849,7 @@
     },
     "node_modules/@treeseed/sdk": {
       "version": "0.12.63-dev.fix-sdk-package-lock-integrity.20260818T124913Z",
-      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#8cef5fb4beea8751eaece91cdfe62de007930360",
+      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#5db07e79bbd32bcd753d7600d15b7412357fc8c5",
       "integrity": "sha512-WEuDEN/5h/DJWdul+QeYl9K2Tpc70LWdvdo8zxuktat5f9Vi67OFd424v94fTok9SDrIAKzS00pzchIdecUmsQ==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@treeseed/agent": "github:treeseed-ai/agent#6e1a7345e6ec1c75d8020ce4c08c68bea7ad99e7",
         "@treeseed/core": "github:treeseed-ai/core#32a5c1eeb5f6e5e655910f679c684bf4f2cad244",
-        "@treeseed/sdk": "github:treeseed-ai/sdk#2412568c6b311978c896f283b6af845f4e65b928",
+        "@treeseed/sdk": "github:treeseed-ai/sdk#8cef5fb4beea8751eaece91cdfe62de007930360",
         "@treeseed/ui": "github:treeseed-ai/ui#d622525826d4222ced78e7748880750f6c1377bb",
         "ink": "^7.0.0",
         "react": "^19.2.5",
@@ -8849,7 +8849,7 @@
     },
     "node_modules/@treeseed/sdk": {
       "version": "0.12.63-dev.fix-sdk-package-lock-integrity.20260818T124913Z",
-      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#2412568c6b311978c896f283b6af845f4e65b928",
+      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#8cef5fb4beea8751eaece91cdfe62de007930360",
       "integrity": "sha512-WEuDEN/5h/DJWdul+QeYl9K2Tpc70LWdvdo8zxuktat5f9Vi67OFd424v94fTok9SDrIAKzS00pzchIdecUmsQ==",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@treeseed/agent": "github:treeseed-ai/agent#6e1a7345e6ec1c75d8020ce4c08c68bea7ad99e7",
         "@treeseed/core": "github:treeseed-ai/core#32a5c1eeb5f6e5e655910f679c684bf4f2cad244",
-        "@treeseed/sdk": "github:treeseed-ai/sdk#92a66135fbda5575bee058b0ab25339c6c7d6398",
+        "@treeseed/sdk": "github:treeseed-ai/sdk#c12d422516a9de3a501b5c48c9d15363550add0c",
         "@treeseed/ui": "github:treeseed-ai/ui#d622525826d4222ced78e7748880750f6c1377bb",
         "ink": "^7.0.0",
         "react": "^19.2.5",
@@ -8849,8 +8849,8 @@
     },
     "node_modules/@treeseed/sdk": {
       "version": "0.12.63-dev.fix-sdk-package-lock-integrity.20260818T124913Z",
-      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#92a66135fbda5575bee058b0ab25339c6c7d6398",
-      "integrity": "sha512-6w9qNqZCmHdgme7C3Ab14xUz5UnAz0HPq5+u1t3fE9Wb3OStn4TQbS6kGJ/l9wwPdoixjD0V2VOcjmjXIzsiuA==",
+      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#c12d422516a9de3a501b5c48c9d15363550add0c",
+      "integrity": "sha512-WEuDEN/5h/DJWdul+QeYl9K2Tpc70LWdvdo8zxuktat5f9Vi67OFd424v94fTok9SDrIAKzS00pzchIdecUmsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@github/copilot": "1.0.39",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@treeseed/agent": "github:treeseed-ai/agent#6e1a7345e6ec1c75d8020ce4c08c68bea7ad99e7",
     "@treeseed/core": "github:treeseed-ai/core#32a5c1eeb5f6e5e655910f679c684bf4f2cad244",
-    "@treeseed/sdk": "github:treeseed-ai/sdk#92a66135fbda5575bee058b0ab25339c6c7d6398",
+    "@treeseed/sdk": "github:treeseed-ai/sdk#c12d422516a9de3a501b5c48c9d15363550add0c",
     "@treeseed/ui": "github:treeseed-ai/ui#d622525826d4222ced78e7748880750f6c1377bb",
     "ink": "^7.0.0",
     "react": "^19.2.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@treeseed/agent": "github:treeseed-ai/agent#6e1a7345e6ec1c75d8020ce4c08c68bea7ad99e7",
     "@treeseed/core": "github:treeseed-ai/core#32a5c1eeb5f6e5e655910f679c684bf4f2cad244",
-    "@treeseed/sdk": "github:treeseed-ai/sdk#c12d422516a9de3a501b5c48c9d15363550add0c",
+    "@treeseed/sdk": "github:treeseed-ai/sdk#2412568c6b311978c896f283b6af845f4e65b928",
     "@treeseed/ui": "github:treeseed-ai/ui#d622525826d4222ced78e7748880750f6c1377bb",
     "ink": "^7.0.0",
     "react": "^19.2.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@treeseed/agent": "github:treeseed-ai/agent#6e1a7345e6ec1c75d8020ce4c08c68bea7ad99e7",
     "@treeseed/core": "github:treeseed-ai/core#32a5c1eeb5f6e5e655910f679c684bf4f2cad244",
-    "@treeseed/sdk": "github:treeseed-ai/sdk#8cef5fb4beea8751eaece91cdfe62de007930360",
+    "@treeseed/sdk": "github:treeseed-ai/sdk#5db07e79bbd32bcd753d7600d15b7412357fc8c5",
     "@treeseed/ui": "github:treeseed-ai/ui#d622525826d4222ced78e7748880750f6c1377bb",
     "ink": "^7.0.0",
     "react": "^19.2.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@treeseed/agent": "github:treeseed-ai/agent#6e1a7345e6ec1c75d8020ce4c08c68bea7ad99e7",
     "@treeseed/core": "github:treeseed-ai/core#32a5c1eeb5f6e5e655910f679c684bf4f2cad244",
-    "@treeseed/sdk": "github:treeseed-ai/sdk#2412568c6b311978c896f283b6af845f4e65b928",
+    "@treeseed/sdk": "github:treeseed-ai/sdk#8cef5fb4beea8751eaece91cdfe62de007930360",
     "@treeseed/ui": "github:treeseed-ai/ui#d622525826d4222ced78e7748880750f6c1377bb",
     "ink": "^7.0.0",
     "react": "^19.2.5",

--- a/src/cli/handlers/projects/governance/contribution.ts
+++ b/src/cli/handlers/projects/governance/contribution.ts
@@ -1,0 +1,28 @@
+import { validateProjectContributionAuthorization } from '@treeseed/sdk/work-providers';
+import { readFile,writeFile,mkdir } from 'node:fs/promises';
+import { dirname,resolve } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import type { CommandHandler,ParsedInvocation } from '../../../types.js';
+import { createMarketClientForInvocation } from '../../content/market-utils.js';
+import { fail,guidedResult } from '../../utilities/utils.js';
+
+const text=(invocation:ParsedInvocation,name:string)=>typeof invocation.args[name]==='string'&&String(invocation.args[name]).trim()?String(invocation.args[name]).trim():null;
+const payload=(value:any)=>value?.payload??value;
+async function document(invocation:ParsedInvocation,cwd:string){const inline=text(invocation,'document');const file=text(invocation,'file');if(inline&&file)throw new Error('Use only one of --file or --document.');if(!inline&&!file)return{};const value=parseYaml(inline??await readFile(resolve(cwd,file!),'utf8'));if(!value||typeof value!=='object'||Array.isArray(value))throw new Error('Contribution input must be an object.');return value;}
+
+export const handleContribution:CommandHandler=async(invocation,context)=>{
+	const action=invocation.positionals[0];const projectId=text(invocation,'project');if(!action||!projectId)return fail('Use `trsd contribution <plan|apply|show|revoke|project|diagnose> --project <project-id>`.');
+	let market;try{market=createMarketClientForInvocation(invocation,context,{requireAuth:true,allowLocalAcceptanceAdmin:false});}catch(error){return fail(error instanceof Error?error.message:String(error));}
+	const request=(path:string,options:Record<string,unknown>={})=>market.client.request(path,{...options,requireAuth:true});const root=`/v1/projects/${encodeURIComponent(projectId)}/contribution-authorizations`;
+	try{
+		let result:any;
+		if(action==='show')result=payload(await request(root));
+		else if(action==='plan')result=payload(await request(`${root}/plan`,{method:'POST',body:await document(invocation,context.cwd)}));
+		else if(action==='apply'){if(invocation.args.yes!==true)return fail('Applying standing contribution authorization requires --yes after reviewing the exact plan digest.');result=payload(await request(`${root}/apply`,{method:'POST',body:await document(invocation,context.cwd)}));}
+		else if(action==='revoke'){const id=text(invocation,'authorization');if(!id||invocation.args.yes!==true)return fail('Revocation requires --authorization and --yes.');result=payload(await request(`${root}/${encodeURIComponent(id)}/revoke`,{method:'POST',body:{}}));}
+		else if(action==='diagnose'){const listed=payload(await request(root));const authorization=Array.isArray(listed.items)?listed.items.find((item:any)=>item.status==='active'):null;const diagnostics=authorization?validateProjectContributionAuthorization(authorization).diagnostics:[{code:'contribution_authorization_missing',path:'authorization',message:'No active project authorization.'}];const agent=text(invocation,'agent');const provider=text(invocation,'provider');const branch=text(invocation,'branch');if(authorization&&agent&&!authorization.agentIds.includes(agent))diagnostics.push({code:'contribution_agent_unauthorized',path:'agent',message:'Agent is outside the standing grant.'});if(authorization&&provider&&!authorization.capacityProviderIds.includes(provider))diagnostics.push({code:'contribution_provider_unauthorized',path:'provider',message:'Provider is outside the standing grant.'});if(authorization&&branch&&!authorization.targetBranches.includes(branch))diagnostics.push({code:'contribution_branch_unauthorized',path:'branch',message:'Branch is outside the standing grant.'});result={ok:diagnostics.length===0,authorization,diagnostics};}
+		else if(action==='project'){if(invocation.args.yes!==true)return fail('Projecting a trusted base policy requires --yes.');const listed=payload(await request(root));const authorization=Array.isArray(listed.items)?listed.items.find((item:any)=>item.status==='active'):null;if(!authorization)return fail('No active project contribution authorization can be projected.');const output=resolve(context.cwd,text(invocation,'output')??'.treeseed/contribution-policy.json');await mkdir(dirname(output),{recursive:true});await writeFile(output,`${JSON.stringify({schemaVersion:'treeseed.contribution-policy/v1',projectId,repository:authorization.repository,activeAuthorization:authorization},null,2)}\n`,{encoding:'utf8',mode:0o644});result={output,authorizationId:authorization.id,generation:authorization.generation};}
+		else return fail(`Unknown contribution action ${action}.`);
+		return guidedResult({command:`contribution ${action}`,summary:`Contribution ${action} completed for project ${projectId}.`,facts:[{label:'Project',value:projectId},{label:'Authorization',value:String(result.authorization?.id??result.authorizationId??result.id??'none')},{label:'Status',value:String(result.authorization?.status??result.status??(result.ok===false?'blocked':'available'))}],report:{marketId:market.profile.id,action,projectId,result}});
+	}catch(error){return fail(error instanceof Error?error.message:String(error));}
+};

--- a/src/cli/operations/operations-registry.ts
+++ b/src/cli/operations/operations-registry.ts
@@ -27,6 +27,7 @@ import { agentRuntimeOperationSpecs } from './operations-agent-runtime.ts';
 import { serviceOperationSpecs } from '../services/operations-services.ts';
 import { contentOperationSpecs } from '../content/operations-content.ts';
 import { governanceOperationSpecs } from '../projects/governance/operations-governance.ts';
+import { contributionOperationSpecs } from '../projects/governance/operations-contribution.ts';
 import { knowledgeOperationSpecs } from '../projects/knowledge/operations-knowledge.ts';
 import { platformRunOperationSpecs } from './operations-platform-run.ts';
 
@@ -55,6 +56,7 @@ const CLI_ONLY_OPERATION_SPECS = [
 	...serviceOperationSpecs,
 	...contentOperationSpecs,
 	...governanceOperationSpecs,
+	...contributionOperationSpecs,
 	...knowledgeOperationSpecs,
 	...platformRunOperationSpecs,
 ];

--- a/src/cli/projects/governance/operations-contribution.ts
+++ b/src/cli/projects/governance/operations-contribution.ts
@@ -1,0 +1,21 @@
+import type { OperationSpec } from '../../operations/operations-types.ts';
+
+export const contributionOperationSpecs:OperationSpec[]=[{
+	id:'project.contribution-authorization',name:'contribution',aliases:[],group:'Utilities',summary:'Manage human-owned project contribution authorization and diagnose delegated agent eligibility.',
+	description:'Plans, applies, reads, revokes, projects, and diagnoses standing project contribution authorization without permitting agents to grant legal authority.',provider:'default',related:['governance','capacity'],
+	usage:'trsd contribution <plan|apply|show|revoke|project|diagnose> --project <project-id> [--file <yaml>] [--market local] [--yes] [--json]',arguments:[{name:'action',description:'Contribution authorization action.',required:true}],
+	options:[
+		{name:'market',flags:'--market <id-or-url>',description:'Configured market id or local API URL.',kind:'string'},
+		{name:'project',flags:'--project <project-id>',description:'TreeSeed project identifier.',kind:'string'},
+		{name:'authorization',flags:'--authorization <authorization-id>',description:'Standing authorization to revoke.',kind:'string'},
+		{name:'file',flags:'--file <path>',description:'YAML or JSON scope/plan document.',kind:'string'},
+		{name:'document',flags:'--document <yaml-or-json>',description:'Inline YAML or JSON scope/plan document.',kind:'string'},
+		{name:'output',flags:'--output <path>',description:'Safe public project policy output path.',kind:'string'},
+		{name:'agent',flags:'--agent <agent-id>',description:'Agent identity to diagnose.',kind:'string'},
+		{name:'provider',flags:'--provider <capacity-provider-id>',description:'Capacity provider identity to diagnose.',kind:'string'},
+		{name:'branch',flags:'--branch <target-branch>',description:'Target branch to diagnose.',kind:'string'},
+		{name:'yes',flags:'--yes',description:'Confirm apply, revoke, or policy projection after inspecting plan.',kind:'boolean'},
+		{name:'json',flags:'--json',description:'Emit machine-readable JSON.',kind:'boolean'},
+	],examples:['trsd contribution plan --market local --project project_123 --file contribution-scope.yaml --json','trsd contribution apply --market local --project project_123 --file reviewed-plan.yaml --yes --json','trsd contribution diagnose --market local --project project_123 --agent agent:engineer --provider provider_123 --branch staging --json'],
+	help:{longSummary:['A human team owner grants once at project scope; agents only consume exact scoped receipts.'],whenToUse:['Use before activating agent-authored staging PRs.'],beforeYouRun:['Plan first and inspect the exact grant text, identities, repository, branches, expiry, and digest.'],automationNotes:['Agents may run show and diagnose. Apply, revoke, and project require human authority and --yes.']},helpVisible:true,helpFeatured:false,executionMode:'handler',handlerName:'contribution',
+}];

--- a/src/cli/support/registry.ts
+++ b/src/cli/support/registry.ts
@@ -60,6 +60,7 @@ import { handleClean } from '../handlers/diagnostics/cleanup.js';
 import { handleServices } from '../handlers/services/services.js';
 import { handleContent } from '../handlers/content/content.js';
 import { handleGovernance } from '../handlers/projects/governance/governance.js';
+import { handleContribution } from '../handlers/projects/governance/contribution.js';
 import { handleKnowledge } from '../handlers/projects/knowledge/knowledge.js';
 import { handlePlatform, handleRun } from '../handlers/runtime/run.js';
 
@@ -127,6 +128,7 @@ export const COMMAND_HANDLERS = {
 	services: handleServices,
 	content: handleContent,
 	governance: handleGovernance,
+	contribution: handleContribution,
 	knowledge: handleKnowledge,
 } as const;
 

--- a/tests/unit/registry/contribution-command.test.ts
+++ b/tests/unit/registry/contribution-command.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { findOperation } from '../../../src/cli/operations/operations-registry.ts';
+
+test('contribution exposes one-time human grant and agent-safe diagnostic actions',()=>{
+	const operation=findOperation('contribution');assert.ok(operation);assert.equal(operation.handlerName,'contribution');
+	assert.match(operation.usage,/plan\|apply\|show\|revoke\|project\|diagnose/u);
+	const options=new Map(operation.options?.map((option)=>[option.name,option]));
+	for(const name of ['market','project','authorization','file','document','output','agent','provider','branch','yes','json'])assert.ok(options.has(name),`missing ${name}`);
+	assert.match(operation.help?.automationNotes?.join(' ')??'',/Agents may run show and diagnose/u);
+});


### PR DESCRIPTION
## Outcome

Adds operator commands for planning, applying, inspecting, projecting, diagnosing, and revoking human-owned standing project contribution authorizations.

## Work authority

- Work item / Issue: Platform ledger `CONTRIBUTION-AUTH-001`
- Proposal / decision: user-approved project-scoped standing authorization architecture
- Actor: Codex primary implementation agent
- Human authority: @havensadrian
- Exact base ref: staging 125cfa22fcf50f447c6fe9dda8ebb3b218276b48
- Exact head ref: codex/project-contribution-authorization bc46fcd9f25a8e31514c0d0bf5bfadf43b91be6d

Contributor mode:

- [x] Agent-assisted under human authority

## Plan

1. Expose plan/apply/show/revoke/project/diagnose over the API contract.
2. Require explicit `--yes` for human-owned mutations.
3. Allow agents only read/diagnostic operations.
4. Project only the active public authorization into the repository policy file.

## Verification

- Contribution registry and operations registry: 5 tests passed.
- `npm run build` — passed.
- `git diff --check` — passed.
- Exact-head push/PR Verify and Content passed against SDK head 5db07e79bbd32bcd753d7600d15b7412357fc8c5.

## Risk and rollback

No grant is created by this PR. API authorization remains authoritative; CLI policy projection contains only public verification material. Revert with the companion SDK/API/Agent changes before activation.

## Submission checklist

- [x] Change is bounded to `CONTRIBUTION-AUTH-001`.
- [x] Exact base/head refs are recorded.
- [x] Hosted and cross-package acceptance is complete.
- [x] No plaintext secrets or machine state are included.



