### PR TITLE
ci: add npm-only CLI prerelease

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,26 +7,92 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
-    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
-    runs-on: ubuntu-latest
+  npm:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-24.04
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288ca8642d1e84afbd3f7d6820020
         with:
-          submodules: recursive
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24.12.0
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - run: npm run release:setup
+      - run: npm run release:check-tag
       - run: bash -lc 'npm run verify:local'
-      - run: npm publish --access public
+      - name: Pack the exact verified package
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          npm pack --json --ignore-scripts --pack-destination artifacts > artifacts/pack.json
+          filename="$(node -e "const value=require('./artifacts/pack.json'); process.stdout.write(value[0].filename)")"
+          sha256="$(sha256sum "artifacts/${filename}" | awk '{print $1}')"
+          echo "filename=${filename}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: cli-release-${{ github.sha }}
+          path: artifacts/
+          if-no-files-found: error
+      - name: Capture stable tag before publication
+        id: before
+        run: echo "latest=$(npm view @treeseed/cli dist-tags.latest)" >> "$GITHUB_OUTPUT"
+      - run: npm run release:publish -- "artifacts/${{ steps.pack.outputs.filename }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Verify immutable npm read-back
+        env:
+          EXPECTED_LATEST: ${{ steps.before.outputs.latest }}
+          EXPECTED_SHA256: ${{ steps.pack.outputs.sha256 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          deadline=$((SECONDS + 180))
+          while true; do
+            published="$(npm view "@treeseed/cli@${GITHUB_REF_NAME}" version 2>/dev/null || true)"
+            channel="latest"
+            if [[ "${GITHUB_REF_NAME}" == *-rc.* ]]; then channel="rc"; fi
+            tagged="$(npm view "@treeseed/cli" "dist-tags.${channel}" 2>/dev/null || true)"
+            if [[ "${published}" == "${GITHUB_REF_NAME}" && "${tagged}" == "${GITHUB_REF_NAME}" ]]; then break; fi
+            if (( SECONDS >= deadline )); then echo "npm read-back did not converge" >&2; exit 1; fi
+            sleep 3
+          done
+          if [[ "${GITHUB_REF_NAME}" == *-rc.* ]]; then
+            latest="$(npm view @treeseed/cli dist-tags.latest)"
+            [[ "${latest}" == "${EXPECTED_LATEST}" ]] || { echo "prerelease changed npm latest" >&2; exit 1; }
+          fi
+          temp="$(mktemp -d)"
+          npm pack "@treeseed/cli@${GITHUB_REF_NAME}" --ignore-scripts --pack-destination "${temp}" >/dev/null
+          actual="$(sha256sum "${temp}"/*.tgz | awk '{print $1}')"
+          [[ "${actual}" == "${EXPECTED_SHA256}" ]] || { echo "published tarball digest mismatch" >&2; exit 1; }
+
+  release:
+    needs: npm
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag
+
+  prerelease:
+    needs: npm
+    if: startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-rc.')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Create GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag --prerelease

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,27 +49,7 @@ jobs:
         env:
           EXPECTED_LATEST: ${{ steps.before.outputs.latest }}
           EXPECTED_SHA256: ${{ steps.pack.outputs.sha256 }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          deadline=$((SECONDS + 180))
-          while true; do
-            published="$(npm view "@treeseed/cli@${GITHUB_REF_NAME}" version 2>/dev/null || true)"
-            channel="latest"
-            if [[ "${GITHUB_REF_NAME}" == *-rc.* ]]; then channel="rc"; fi
-            tagged="$(npm view "@treeseed/cli" "dist-tags.${channel}" 2>/dev/null || true)"
-            if [[ "${published}" == "${GITHUB_REF_NAME}" && "${tagged}" == "${GITHUB_REF_NAME}" ]]; then break; fi
-            if (( SECONDS >= deadline )); then echo "npm read-back did not converge" >&2; exit 1; fi
-            sleep 3
-          done
-          if [[ "${GITHUB_REF_NAME}" == *-rc.* ]]; then
-            latest="$(npm view @treeseed/cli dist-tags.latest)"
-            [[ "${latest}" == "${EXPECTED_LATEST}" ]] || { echo "prerelease changed npm latest" >&2; exit 1; }
-          fi
-          temp="$(mktemp -d)"
-          npm pack "@treeseed/cli@${GITHUB_REF_NAME}" --ignore-scripts --pack-destination "${temp}" >/dev/null
-          actual="$(sha256sum "${temp}"/*.tgz | awk '{print $1}')"
-          [[ "${actual}" == "${EXPECTED_SHA256}" ]] || { echo "published tarball digest mismatch" >&2; exit 1; }
+        run: node --import tsx ./scripts/packages/verify-published-package.ts
 
   release:
     needs: npm

--- a/scripts/packages/assert-release-tag-version.ts
+++ b/scripts/packages/assert-release-tag-version.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parseCliReleaseVersion } from './release-version.ts';
 
 const packageRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const packageJson = JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8'));
@@ -12,14 +13,10 @@ if (!tagName) {
 	process.exit(1);
 }
 
-if (!/^\d+\.\d+\.\d+$/.test(tagName)) {
-	console.error(`Release tag "${tagName}" must use plain semver format "x.y.z".`);
-	process.exit(1);
-}
-
-const taggedVersion = tagName;
-if (taggedVersion !== packageVersion) {
-	console.error(`Release tag version "${taggedVersion}" does not match @treeseed/cli version "${packageVersion}".`);
+try {
+	parseCliReleaseVersion(tagName, packageVersion);
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
 	process.exit(1);
 }
 

--- a/scripts/packages/publish-package.ts
+++ b/scripts/packages/publish-package.ts
@@ -1,17 +1,26 @@
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
+import { parseCliReleaseVersion } from './release-version.ts';
 
 const packageRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const extraArgs = process.argv.slice(2);
 const tagName = process.env.GITHUB_REF_NAME;
+const packageVersion = String(JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8')).version);
 
-if (tagName && !/^\d+\.\d+\.\d+$/.test(tagName)) {
-	console.error(`Refusing to publish @treeseed/cli from non-stable tag "${tagName}".`);
-	process.exit(1);
+let distTag = 'latest';
+if (tagName) {
+	try {
+		distTag = parseCliReleaseVersion(tagName, packageVersion).distTag;
+	} catch (error) {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exit(1);
+	}
 }
 
-const npmArgs = ['publish', '.', '--access', 'public'];
+const publishTarget = extraArgs[0]?.endsWith('.tgz') ? resolve(packageRoot, extraArgs.shift()!) : '.';
+const npmArgs = ['publish', publishTarget, '--access', 'public', '--tag', distTag];
 if (process.env.GITHUB_ACTIONS === 'true') npmArgs.push('--provenance');
 npmArgs.push(...extraArgs);
 

--- a/scripts/packages/published-package-readback.ts
+++ b/scripts/packages/published-package-readback.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export class RegistryPropagationError extends Error {}
+
+export type PublishedPackageReadbackInput = {
+	packageName: string;
+	packageVersion: string;
+	packageDigest: string;
+	distTag: 'latest' | 'rc';
+	expectedLatest: string;
+	destination: string;
+	cwd: string;
+	deadlineMs?: number;
+	perCallTimeoutMs?: number;
+	execNpm?: (args: string[], timeout: number) => string;
+	readArtifact?: (path: string) => Buffer;
+	now?: () => number;
+	delay?: (milliseconds: number) => Promise<void>;
+};
+
+const retryableRegistryFailure = (error: unknown): boolean => {
+	if (error instanceof RegistryPropagationError) return true;
+	const detail = error as { stdout?: unknown; stderr?: unknown };
+	const output = `${String(detail.stdout ?? '')}\n${String(detail.stderr ?? '')}\n${error instanceof Error ? error.message : String(error)}`;
+	return ['E404', 'ETARGET', 'EAI_AGAIN', 'ECONNRESET', 'ETIMEDOUT', 'E502', 'E503', 'E504', 'FETCH_ERROR']
+		.some((marker) => output.includes(marker));
+};
+
+export async function readBackPublishedPackage(input: PublishedPackageReadbackInput) {
+	const now = input.now ?? Date.now;
+	const delay = input.delay ?? ((milliseconds: number) => new Promise<void>((resolveDelay) => setTimeout(resolveDelay, milliseconds)));
+	const deadline = now() + (input.deadlineMs ?? 180_000);
+	const perCallTimeout = input.perCallTimeoutMs ?? 15_000;
+	const execNpm = input.execNpm ?? ((args, timeout) => execFileSync('npm', args, {
+		cwd: input.cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout,
+	}));
+	const readArtifact = input.readArtifact ?? readFileSync;
+	const remainingTimeout = () => Math.max(1, Math.min(perCallTimeout, deadline - now()));
+	const waitForPropagation = async (error: unknown) => {
+		if (!retryableRegistryFailure(error) || now() >= deadline) throw error;
+		await delay(Math.min(3000, Math.max(1, deadline - now())));
+	};
+
+	let observedDigest = '';
+	while (!observedDigest) {
+		try {
+			const packed = JSON.parse(execNpm([
+				'pack', `${input.packageName}@${input.packageVersion}`, '--json', '--ignore-scripts', '--prefer-online',
+				'--pack-destination', input.destination,
+			], remainingTimeout())) as Array<{ filename: string }>;
+			observedDigest = createHash('sha256').update(readArtifact(resolve(input.destination, packed[0]!.filename))).digest('hex');
+		} catch (error) {
+			await waitForPropagation(error);
+		}
+	}
+	if (observedDigest !== input.packageDigest) {
+		throw new Error(`Published CLI digest ${observedDigest} does not match ${input.packageDigest}.`);
+	}
+
+	let tags: Record<string, string> = {};
+	while (tags[input.distTag] !== input.packageVersion) {
+		try {
+			tags = JSON.parse(execNpm(['view', input.packageName, 'dist-tags', '--json', '--prefer-online'], remainingTimeout())) as Record<string, string>;
+			if (tags.latest !== input.expectedLatest) throw new Error(`npm latest changed from ${input.expectedLatest} to ${tags.latest ?? 'nothing'}.`);
+			if (tags[input.distTag] !== input.packageVersion) {
+				throw new RegistryPropagationError(`npm ${input.distTag} points to ${tags[input.distTag] ?? 'nothing'}, expected ${input.packageVersion}.`);
+			}
+		} catch (error) {
+			await waitForPropagation(error);
+		}
+	}
+	return { packageVersion: input.packageVersion, packageDigest: observedDigest, distTag: input.distTag, latest: tags.latest! };
+}

--- a/scripts/packages/release-version.ts
+++ b/scripts/packages/release-version.ts
@@ -1,0 +1,8 @@
+export function parseCliReleaseVersion(tagName: string, packageVersion: string) {
+	if (tagName !== packageVersion) {
+		throw new Error(`Release tag "${tagName}" does not match @treeseed/cli version "${packageVersion}".`);
+	}
+	if (/^\d+\.\d+\.\d+$/u.test(tagName)) return { channel: 'stable' as const, distTag: 'latest' as const };
+	if (/^\d+\.\d+\.\d+-rc\.\d+$/u.test(tagName)) return { channel: 'prerelease' as const, distTag: 'rc' as const };
+	throw new Error(`Release tag "${tagName}" must be an exact stable or rc.N semantic version.`);
+}

--- a/scripts/packages/verify-published-package.ts
+++ b/scripts/packages/verify-published-package.ts
@@ -1,0 +1,28 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { parseCliReleaseVersion } from './release-version.ts';
+import { readBackPublishedPackage } from './published-package-readback.ts';
+
+const root = resolve(import.meta.dirname, '../..');
+const packageDocument = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as { name: string; version: string };
+const tagName = process.env.GITHUB_REF_NAME ?? '';
+const release = parseCliReleaseVersion(tagName, packageDocument.version);
+const packageDigest = process.env.EXPECTED_SHA256?.trim();
+const previousLatest = process.env.EXPECTED_LATEST?.trim();
+if (!packageDigest || !previousLatest) throw new Error('Published read-back requires EXPECTED_SHA256 and EXPECTED_LATEST.');
+const destination = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-published-'));
+try {
+	const result = await readBackPublishedPackage({
+		packageName: packageDocument.name,
+		packageVersion: packageDocument.version,
+		packageDigest,
+		distTag: release.distTag,
+		expectedLatest: release.distTag === 'rc' ? previousLatest : packageDocument.version,
+		destination,
+		cwd: root,
+	});
+	console.log(JSON.stringify({ ok: true, ...result }));
+} finally {
+	rmSync(destination, { recursive: true, force: true });
+}

--- a/tests/contract/package/published-package-readback.test.ts
+++ b/tests/contract/package/published-package-readback.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readBackPublishedPackage } from '../../../scripts/packages/published-package-readback.ts';
+
+const artifact = Buffer.from('verified-cli-artifact');
+const digest = createHash('sha256').update(artifact).digest('hex');
+const input = {
+	packageName: '@treeseed/cli', packageVersion: '0.13.0-rc.1', packageDigest: digest,
+	distTag: 'rc' as const, expectedLatest: '0.12.58', destination: '/fixture', cwd: '/fixture',
+	readArtifact: () => artifact,
+};
+
+test('published read-back retries only visibility and dist-tag propagation', async () => {
+	const notVisible = Object.assign(new Error('not visible'), { stderr: 'npm ERR! code ETARGET' });
+	const values: Array<string | Error> = [notVisible, '[{"filename":"package.tgz"}]', '{"latest":"0.12.58"}', '{"latest":"0.12.58","rc":"0.13.0-rc.1"}'];
+	let calls = 0;
+	let now = 0;
+	const result = await readBackPublishedPackage({
+		...input,
+		execNpm: () => { const value = values[calls++]!; if (value instanceof Error) throw value; return value; },
+		now: () => now,
+		delay: async (milliseconds) => { now += milliseconds; },
+	});
+	assert.deepEqual(result, { packageVersion: '0.13.0-rc.1', packageDigest: digest, distTag: 'rc', latest: '0.12.58' });
+	assert.equal(calls, 4);
+});
+
+test('published read-back stops at its overall deadline', async () => {
+	const timeout = Object.assign(new Error('timed out'), { stderr: 'npm ERR! code ETIMEDOUT' });
+	let now = 0;
+	let calls = 0;
+	await assert.rejects(readBackPublishedPackage({
+		...input,
+		execNpm: () => { calls += 1; throw timeout; },
+		deadlineMs: 5,
+		now: () => now,
+		delay: async (milliseconds) => { now += milliseconds; },
+	}), /timed out/u);
+	assert.equal(now, 5);
+	assert.equal(calls, 2);
+});
+
+test('published read-back fails immediately on authentication errors', async () => {
+	let delays = 0;
+	await assert.rejects(readBackPublishedPackage({
+		...input,
+		execNpm: () => { throw Object.assign(new Error('unauthorized'), { stderr: 'npm ERR! code E401' }); },
+		delay: async () => { delays += 1; },
+	}), /unauthorized/u);
+	assert.equal(delays, 0);
+});
+
+test('published read-back fails immediately when latest moves', async () => {
+	const values = ['[{"filename":"package.tgz"}]', '{"latest":"0.13.0-rc.1","rc":"0.13.0-rc.1"}'];
+	let calls = 0;
+	await assert.rejects(readBackPublishedPackage({ ...input, execNpm: () => values[calls++]! }), /npm latest changed/u);
+	assert.equal(calls, 2);
+});
+
+test('published read-back checks artifact identity before dist-tags', async () => {
+	let calls = 0;
+	await assert.rejects(readBackPublishedPackage({
+		...input, packageDigest: 'wrong', execNpm: () => { calls += 1; return '[{"filename":"package.tgz"}]'; },
+	}), /does not match/u);
+	assert.equal(calls, 1);
+});

--- a/tests/contract/package/release-version.test.ts
+++ b/tests/contract/package/release-version.test.ts
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCliReleaseVersion } from '../../../scripts/packages/release-version.ts';
+
+test('CLI release versions route stable and RC artifacts to isolated npm tags', () => {
+	assert.deepEqual(parseCliReleaseVersion('0.13.0', '0.13.0'), { channel: 'stable', distTag: 'latest' });
+	assert.deepEqual(parseCliReleaseVersion('0.13.0-rc.1', '0.13.0-rc.1'), { channel: 'prerelease', distTag: 'rc' });
+});
+
+test('CLI release versions reject mismatches and unsupported prerelease channels', () => {
+	assert.throws(() => parseCliReleaseVersion('0.13.0-rc.1', '0.13.0-rc.2'), /does not match/u);
+	assert.throws(() => parseCliReleaseVersion('0.13.0-beta.1', '0.13.0-beta.1'), /stable or rc\.N/u);
+	assert.throws(() => parseCliReleaseVersion('v0.13.0', 'v0.13.0'), /stable or rc\.N/u);
+});


### PR DESCRIPTION
## Outcome

Adds an npm-only semantic prerelease path for CLI RCs while preserving npm `latest` and preventing unrelated package publication.

## Work authority

- Work item / Issue: Closes #14
- Proposal / decision: Gate 2 Human CLI and time-based workday prerequisite
- Assignment / checkpoint: Pre-agent implementation; no live TreeSeed assignment or workday
- Actor: OpenAI Codex under Adrian Webb's direction
- Human authority: Adrian Webb
- Agent / capacity provider: Codex development agent; no TreeSeed capacity-provider lease
- Exact base ref: `staging` at `88c1b90ef527a52ca57d77475257d9493bcbf94b`
- Exact head ref: `codex/cli-rc-publication` at `ed1822d7109bc18fbaa3636dc989fece82aaeb98`

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

1. Accept only exact stable or `rc.N` semantic tags that equal `package.json`.
2. Route RCs only to npm `rc`; retain stable `latest` behavior.
3. Verify and upload the exact tarball before publication, then compare registry tar bytes and dist-tags after publication.
4. Create a GitHub prerelease for RCs without publishing any other TreeSeed package or production artifact.
5. Pin credential-bearing workflow actions to immutable commits.

Status: implemented and verified; ready for governed staging merge.

## Changes and commits

- `4c40db3185ec3f763b546c7e2ade7c5b1d598349` — `ci: add npm-only CLI prerelease`
- `ed1822d7109bc18fbaa3636dc989fece82aaeb98` — bound every npm call and the overall read-back deadline; retry only registry visibility and transient transport failures.
- Adds shared release-version policy, tests, exact artifact upload/read-back, `latest` drift protection, prerelease creation, and immutable action identities.

## Verification

- Release-version and bounded registry read-back tests: 7/7 passed, including transient recovery, deadline, authorization, `latest` drift, and digest mismatch cases.
- `npm run lint` passed.
- Full package test campaign: 109/109 passed in 17 suites.
- `GITHUB_REF_NAME=0.13.0-rc.1 npm run release:check-tag` passed.
- Publish workflow YAML parsed.
- Exact packed-tar dry-run selected npm dist-tag `rc`, public access, and the supplied tarball; no network publication occurred locally.
- Package bytes remain the accepted 375-entry CLI candidate, SHA-256 `d622416a7c3cc931bc37af043f745f99cef295a44e58ad94168ac118d47dca10`.
- `git diff --check` passed.
- Hosted push Verify run `32483318383` passed at the exact head.
- Hosted PR Verify run `32483323504` passed at the exact head.

## Risk and rollback

RC npm publication gains trusted automation. The workflow fails on tag/version mismatch, unsupported prerelease channels, changed npm `latest`, registry non-convergence, or tarball digest mismatch. Roll back by reverting this commit before creating the RC tag.

## Completion summary

CLI RC1 can publish independently as a semantic npm prerelease without changing `latest` or publishing another package. Remaining work is hosted verification, staging merge/read-back, tag publication/read-back, and cleanup.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
