### PR TITLE
ci: recover CLI publication as RC2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - uses: actions/setup-node@49933ea5288ca8642d1e84afbd3f7d6820020
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.1",
+  "version": "0.13.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.1",
+      "version": "0.13.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/agent": "0.13.0-rc.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.1",
+  "version": "0.13.0-rc.2",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Outcome

Preserves failed CLI RC1 as immutable evidence and advances the corrected publication candidate to RC2.

## Work authority

- Work item / Issue: Closes #16
- Proposal / decision: Gate 2 Human CLI and time-based workday prerequisite
- Assignment / checkpoint: Pre-agent publication recovery; no live TreeSeed assignment or workday
- Actor: OpenAI Codex under Adrian Webb's direction
- Human authority: Adrian Webb
- Exact base ref: `staging` at `861d3b1546e82367f0efd3a6042d70527d9147b8`
- Exact head ref: `codex/cli-rc2-publication` at `3676d74015a5f1f272cd4894fdf64a4b255e876a`

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

1. Diagnose the RC1 failure before any retry or code change.
2. Preserve the failed RC1 tag; never move or reuse it.
3. Correct the malformed action ref to the reviewed exact 40-character upstream SHA.
4. Advance package and lock consistently to RC2.
5. Re-run hosted verification, exact staging read-back, npm RC publication, digest read-back, and cleanup.

Status: implemented and verified; ready for governed staging merge.

## Changes and commits

- `3676d74015a5f1f272cd4894fdf64a4b255e876a` — correct immutable action identity and advance RC1 to RC2.

## Verification

- Failed publish run `32483738647` made two attempts and failed during action resolution before checkout, credentials, verification, pack, npm publication, or GitHub release.
- Raw workflow inspection found a malformed 38-character `setup-node` ref. The corrected ref `49933ea5288caeca8642d1e84afbd3f7d6820020` is exactly 40 hex characters and resolves upstream.
- Every external action in the npm job is bound to an exact 40-character SHA.
- Release-version and bounded registry read-back tests: 7/7 passed.
- `GITHUB_REF_NAME=0.13.0-rc.2 npm run release:check-tag` passed.
- Exact RC2 package: 375 entries; SHA-256 `797fabe28c9209fb772017705044d66fbca4180d2d5303899fc9a1bb948d462a`.
- npm has no `@treeseed/cli@0.13.0-rc.1`; npm `latest` was not changed.
- `git diff --check` passed.
- Hosted push Verify run `32483985651` passed at the exact head.
- Hosted PR Verify run `32484036768` passed at the exact head.

## Risk and rollback

The change is two version records plus the exact action ref. RC1 remains immutable failed-candidate evidence. Roll back by reverting this commit before tagging RC2; never move either tag.

## Completion summary

The publication code and bounded registry checks remain unchanged. RC2 exists only because RC1's immutable workflow contained a malformed action identity and never reached package verification or npm.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
