### PR TITLE
Render concise human CLI output

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,6 +1,7 @@
 import { setTimeout as delay } from 'node:timers/promises';
 import type { OAuthScope } from '@treeseed/sdk/operator-contracts';
-import { ControlPlaneClientError } from '@treeseed/sdk/control-plane-client';
+import { ControlPlaneClient, ControlPlaneClientError } from '@treeseed/sdk/control-plane-client';
+import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
 import type { CommandContext, ParsedInvocation } from '../types.js';
 import { CONTROL_PLANE_CLI_CLIENT_ID, createControlPlaneClient } from '../support/client.js';
 import { clearServerSession, saveServerProfile, saveServerSession } from '../support/server-custody.js';
@@ -25,9 +26,13 @@ export async function runAuth(invocation: ParsedInvocation, context: CommandCont
 			try {
 				const token = await client.exchangeDeviceCode(CONTROL_PLANE_CLI_CLIENT_ID, authorization.deviceCode);
 				const expiresAt = new Date(Date.now() + token.expiresIn * 1_000).toISOString();
+				const authenticatedClient = new ControlPlaneClient({ profile, accessToken: token.accessToken, userAgent: 'trsd' });
+				const current = await authenticatedClient.invoke(CONTROL_PLANE_OPERATIONS.accounts.current, { path: {}, query: {}, body: undefined });
+				const principal = current.data && typeof current.data === 'object' && 'principal' in current.data
+					? current.data.principal as typeof token.principal : token.principal;
 				saveServerProfile(profile, context.env);
-				saveServerSession({ serverId: profile.serverId, audience: token.audience, accessToken: token.accessToken, refreshToken: token.refreshToken, expiresAt, principal: token.principal }, context.env);
-				return { serverId: profile.serverId, principal: token.principal ?? null, expiresAt, scopes: token.scope };
+				saveServerSession({ serverId: profile.serverId, audience: token.audience, accessToken: token.accessToken, refreshToken: token.refreshToken, expiresAt, principal }, context.env);
+				return { serverId: profile.serverId, principal: principal ?? null, expiresAt, scopes: token.scope };
 			} catch (error) {
 				const state = pollingState(error);
 				if (state === 'failed') throw error;

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -8,6 +8,7 @@ import { runSecrets } from './commands/secrets.js';
 import type { CommandContext, CommandFailure, ParsedInvocation, Writer } from './types.js';
 import { promptText } from './support/prompts.js';
 import { handoffProviderEnrollment } from './support/provider-enrollment.js';
+import { renderHumanCommandResult } from './support/human-renderer.js';
 
 function defaultWrite(output: string, stream: 'stdout' | 'stderr' = 'stdout') {
 	(stream === 'stderr' ? process.stderr : process.stdout).write(`${output}\n`);
@@ -60,7 +61,7 @@ async function execute(invocation: ParsedInvocation, context: CommandContext) {
 
 function print(context: CommandContext, value: unknown, ok = true) {
 	if (context.outputFormat === 'json') context.write(JSON.stringify(value, null, 2), ok ? 'stdout' : 'stderr');
-	else if (ok) context.write(typeof value === 'string' ? value : JSON.stringify(value, null, 2), 'stdout');
+	else if (ok) context.write(typeof value === 'string' ? value : renderHumanCommandResult(value), 'stdout');
 	else {
 		const message = value && typeof value === 'object' && 'error' in value ? (value as { error?: { message?: string } }).error?.message : null;
 		context.write(message ?? String(value), 'stderr');

--- a/src/cli/support/human-renderer.ts
+++ b/src/cli/support/human-renderer.ts
@@ -1,0 +1,57 @@
+function label(value: string) {
+	return value.replace(/([a-z])([A-Z])/gu, '$1 $2').replace(/[_-]+/gu, ' ').replace(/^./u, (character) => character.toUpperCase());
+}
+
+function scalar(value: unknown) {
+	if (typeof value === 'boolean') return value ? 'yes' : 'no';
+	if (value === null || value === undefined || value === '') return 'none';
+	return String(value);
+}
+
+function lines(value: unknown, depth = 0): string[] {
+	if (value === null || value === undefined || typeof value !== 'object') return [scalar(value)];
+	if (Array.isArray(value)) {
+		if (value.length === 0) return ['none'];
+		if (value.every((item) => item === null || typeof item !== 'object')) return [value.map(scalar).join(', ')];
+		return value.flatMap((item) => {
+			const rendered = lines(item, depth + 1);
+			return rendered.map((entry, index) => `${index === 0 ? '- ' : '  '}${entry}`);
+		});
+	}
+	if (depth >= 3) return [`${Object.keys(value as Record<string, unknown>).length} fields`];
+	return Object.entries(value as Record<string, unknown>).flatMap(([key, item]) => {
+		if (item === undefined || item === null) return [];
+		if (typeof item !== 'object') return [`${label(key)}: ${scalar(item)}`];
+		if (Array.isArray(item) && item.every((entry) => entry === null || typeof entry !== 'object')) return [`${label(key)}: ${lines(item, depth + 1)[0]}`];
+		return [`${label(key)}:`, ...lines(item, depth + 1).map((entry) => `  ${entry}`)];
+	});
+}
+
+function principalName(value: unknown) {
+	if (!value || typeof value !== 'object') return null;
+	const principal = value as Record<string, unknown>;
+	return String(principal.displayName ?? principal.username ?? principal.email ?? principal.id ?? '').trim() || null;
+}
+
+export function renderHumanCommandResult(value: unknown) {
+	if (!value || typeof value !== 'object') return scalar(value);
+	const envelope = value as { commandPath?: string[]; ok?: boolean; result?: unknown; warnings?: unknown[]; nextActions?: unknown[] };
+	const path = envelope.commandPath?.join(' ') ?? '';
+	const result = envelope.result as Record<string, unknown> | null;
+	if (path === 'auth login' && result) {
+		const name = principalName(result.principal);
+		return [name ? `Logged in to ${scalar(result.serverId)} as ${name}.` : `Logged in to ${scalar(result.serverId)}.`,
+			result.expiresAt ? `Session expires: ${scalar(result.expiresAt)}` : '',
+			Array.isArray(result.scopes) ? `Scopes: ${result.scopes.map(scalar).join(', ')}` : ''].filter(Boolean).join('\n');
+	}
+	if (path === 'auth logout' && result) return `Logged out of ${scalar(result.serverId)}.`;
+	if (path === 'auth status' && result) {
+		const name = principalName(result.principal);
+		const teams = Array.isArray(result.teams) ? result.teams.length : 0;
+		return `${name ? `Authenticated as ${name}.` : 'Not authenticated.'}\nTeams available: ${teams}`;
+	}
+	const rendered = lines(envelope.result);
+	const warnings = Array.isArray(envelope.warnings) && envelope.warnings.length ? [`Warnings: ${envelope.warnings.map(scalar).join('; ')}`] : [];
+	const next = Array.isArray(envelope.nextActions) && envelope.nextActions.length ? ['Next actions:', ...envelope.nextActions.map((item) => `- ${scalar(item)}`)] : [];
+	return [...rendered, ...warnings, ...next].join('\n') || 'Completed successfully.';
+}

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -162,8 +162,9 @@ test('JSON device login keeps human approval instructions off stdout', async () 
 		response.end(JSON.stringify(request.url === '/oauth/device_authorization'
 			? { device_code: 'device-a', user_code: 'ABCD-EFGH', verification_uri: `${baseUrl}/approve`,
 				verification_uri_complete: `${baseUrl}/approve?user_code=ABCD-EFGH`, expires_in: 60, interval: 0 }
-			: { token_type: 'Bearer', access_token: 'access-a', refresh_token: 'refresh-a', expires_in: 600,
-				scope: 'treeseed:read', audience: baseUrl, principal: { id: 'user-a' } }));
+			: request.url === '/oauth/token' ? { token_type: 'Bearer', access_token: 'access-a', refresh_token: 'refresh-a', expires_in: 600,
+				scope: 'treeseed:read', audience: baseUrl }
+				: { data: { principal: { id: 'user-a', displayName: 'Adrian Webb' }, teams: [] } }));
 	});
 	await new Promise<void>((accept) => server.listen(0, '127.0.0.1', accept));
 	const address = server.address();
@@ -182,6 +183,7 @@ test('JSON device login keeps human approval instructions off stdout', async () 
 		const stdout = output.filter(({ stream }) => stream === 'stdout');
 		assert.equal(stdout.length, 1);
 		assert.equal(JSON.parse(stdout[0]!.value).ok, true);
+		assert.equal(JSON.parse(stdout[0]!.value).result.principal.displayName, 'Adrian Webb');
 	} finally {
 		await new Promise<void>((accept, reject) => server.close((error) => error ? reject(error) : accept()));
 		rmSync(root, { recursive: true, force: true });

--- a/tests/unit/command-boundary/human-renderer.test.ts
+++ b/tests/unit/command-boundary/human-renderer.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createCommandResult } from '@treeseed/sdk/operator-contracts';
+import { renderHumanCommandResult } from '../../../src/cli/support/human-renderer.ts';
+
+test('human login output is concise and contains no command envelope JSON', () => {
+	const output = renderHumanCommandResult(createCommandResult({ commandPath: ['auth', 'login'], mode: 'execute', ok: true,
+		result: { serverId: 'local', principal: { id: 'user-a', displayName: 'Adrian Webb' }, expiresAt: '2027-01-01T00:00:00.000Z', scopes: ['treeseed:read'] },
+		error: null, warnings: [], blockers: [], receipts: [], nextActions: [] }));
+	assert.match(output, /Logged in to local as Adrian Webb\./u);
+	assert.match(output, /Scopes: treeseed:read/u);
+	assert.doesNotMatch(output, /schemaVersion|commandPath|[{}]/u);
+});
+
+test('generic human output renders labels and values without JSON punctuation', () => {
+	const output = renderHumanCommandResult({ commandPath: ['seeds', 'verify'], ok: true,
+		result: { seedName: 'treeseed', verified: true, lanes: ['communication', 'platform', 'workday'] }, warnings: [], nextActions: [] });
+	assert.equal(output, 'Seed Name: treeseed\nVerified: yes\nLanes: communication, platform, workday');
+	assert.doesNotMatch(output, /[{}]/u);
+});


### PR DESCRIPTION
Closes #26\n\nHuman mode now renders concise prose/labels rather than the stable JSON envelope. --json remains unchanged. Device login reads the authenticated account back before storing/rendering the session, so the human receipt identifies the principal.\n\nVerification: command-boundary 14/14; distribution build; diff check.