### PR TITLE
Derive seed identity from uploaded bundle

### DIFF
--- a/src/cli/commands/operator.ts
+++ b/src/cli/commands/operator.ts
@@ -32,9 +32,10 @@ function transform(value: unknown, binding: CommandInputBinding) {
 async function operationInput(invocation: ParsedInvocation, context: CommandContext) {
 	if (invocation.command.execution.kind !== 'operation') throw new Error('Command is not operation-bound.');
 	const input = { path: {} as Record<string, unknown>, query: {} as Record<string, unknown>, body: {} as Record<string, unknown> };
+	const deferred: CommandInputBinding[] = [];
 	for (const binding of invocation.command.execution.input) {
 		const value = transform(sourceValue(binding, invocation, context), binding);
-		if (binding.required && value === undefined) throw Object.assign(new Error(`Missing required ${binding.source}: ${binding.name}`), { category: 'ambiguous_context', code: `${binding.name}_required` });
+		if (binding.required && value === undefined) { deferred.push(binding); continue; }
 		if (value !== undefined) input[binding.target][binding.field] = value;
 	}
 	const operation = controlPlaneOperation(invocation.command.execution.operationId);
@@ -44,6 +45,10 @@ async function operationInput(invocation: ParsedInvocation, context: CommandCont
 		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw Object.assign(new Error('Seed file must contain one portable seed bundle object.'), { category: 'invalid_input', code: 'seed_bundle_file_invalid' });
 		delete input.body.file;
 		input.body.bundle = parsed;
+		if (typeof input.path.name !== 'string' && typeof (parsed as Record<string, unknown>).name === 'string') input.path.name = (parsed as Record<string, unknown>).name;
+	}
+	for (const binding of deferred) if (input[binding.target][binding.field] === undefined) {
+		throw Object.assign(new Error(`Missing required ${binding.source}: ${binding.name}`), { category: 'ambiguous_context', code: `${binding.name}_required` });
 	}
 	return { operation, input: { ...input, body: Object.keys(input.body).length ? input.body : undefined } };
 }

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -75,6 +75,21 @@ test('seed commands upload parsed portable bundles instead of API-local paths', 
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('seed plan derives the path identity from the uploaded portable bundle', async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-seed-plan-'));
+	const file = resolve(root, 'treeseed.yaml');
+	writeFileSync(file, `schemaVersion: treeseed.seed-bundle/v2\nname: treeseed\nversion: 1\ndescription: test\nenvironments: [local]\ndigest: sha256:${'0'.repeat(64)}\nresources:\n  teams: []\n  memberships: []\n  projects: []\n  repositories: []\nruntime:\n  capacityProviders: []\n`);
+	const invocations: any[] = [];
+	try {
+		const exit = await runCommandLine(['seeds', 'plan', file, '--json'], { interactiveUi: false,
+			operationInvoke: async (operationId, input) => { invocations.push({ operationId, input }); return { planned: true }; }, write() {} });
+		assert.equal(exit, 0);
+		assert.equal(invocations[0]?.operationId, 'seeds.plan');
+		assert.equal(invocations[0]?.input.path.name, 'treeseed');
+		assert.equal(invocations[0]?.input.body.bundle.name, 'treeseed');
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('unavailable commands fail closed before network or filesystem mutation', async () => {
 	const output: string[] = [];
 	let invocations = 0;


### PR DESCRIPTION
Closes #28\n\nMakes the documented seeds plan/apply <file> interface self-contained by deriving the API path name from the parsed digest-bound bundle. Missing identities still fail closed.\n\nVerification: command-boundary 15/15; distribution build; diff check.