### PR TITLE
chore(release): adopt virtual knowledge seed contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.6",
+  "version": "0.13.0-rc.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.6",
+      "version": "0.13.0-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.20",
+        "@treeseed/sdk": "0.13.0-rc.22",
         "yaml": "2.8.1"
       },
       "bin": {
@@ -468,12 +468,12 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.20.tgz",
-      "integrity": "sha512-XM2ewAUACIO/umqZEsKlfdJxaDZW8IyMnH5pSoS7vcySKbMb/2bGPwJpfIIuNui9vMAkQ7KwkoIEV5fHXiFUvQ==",
+      "version": "0.13.0-rc.22",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.22.tgz",
+      "integrity": "sha512-bNFCncPrpiY+r7CseA1IEMh4y1vnFnvp6xu+V83OZIum9LH91bTFKu7tWSJcrshxST4eyv6F0XXOoYrqwtNHCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/treedx": "0.3.0-rc.3",
+        "@treeseed/treedx": "0.3.0-rc.4",
         "esbuild": "^0.28.0",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1",
@@ -941,9 +941,9 @@
       }
     },
     "node_modules/@treeseed/treedx": {
-      "version": "0.3.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@treeseed/treedx/-/treedx-0.3.0-rc.3.tgz",
-      "integrity": "sha512-JAp4BywPn0VaFXs+BFnbRj2SGkUmJ7OrS+3mjtCKUVVY7aLJTHgcsnva2G8pCTuY1mjcDSdM3HKWtixiIYt+IA==",
+      "version": "0.3.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@treeseed/treedx/-/treedx-0.3.0-rc.4.tgz",
+      "integrity": "sha512-ZBmY/C30kge84Ns/qzpa/h4XfLXtZMDiyfCJM8WTLHQBU2I5QYrhx2aI32mHk90jQib+SyWfwYMknIip8RHF8A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.6",
+  "version": "0.13.0-rc.7",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -49,7 +49,7 @@
     "release:publish": "node --import tsx ./scripts/packages/publish-package.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.20",
+    "@treeseed/sdk": "0.13.0-rc.22",
     "yaml": "2.8.1"
   },
   "overrides": {

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -11,7 +11,7 @@ test('package has one executable and no runtime package dependency', () => {
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
 	assert.equal(pkg.dependencies.ink, undefined);
 	assert.equal(pkg.dependencies.react, undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.20', yaml: '2.8.1' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.22', yaml: '2.8.1' });
 });
 
 test('built package contains executable runtime only', () => {


### PR DESCRIPTION
Closes #30

## Summary
- pin exact @treeseed/sdk@0.13.0-rc.22
- prepare immutable CLI 0.13.0-rc.7
- retain portable seed upload through catalog operation IDs

## Verification
- canonical command/client boundary: 12/12
- local seed file is parsed and uploaded, never exposed as an API-local path
- CLI build, architecture checks, and dry-run pack pass

The currently running local API predates the v2 seed contract and will be restarted from accepted staging before managed seed verification.