### PR TITLE
fix(seeds): honor catalog path parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.7",
+  "version": "0.13.0-rc.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.7",
+      "version": "0.13.0-rc.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.22",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.7",
+  "version": "0.13.0-rc.8",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/operator.ts
+++ b/src/cli/commands/operator.ts
@@ -45,7 +45,11 @@ async function operationInput(invocation: ParsedInvocation, context: CommandCont
 		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw Object.assign(new Error('Seed file must contain one portable seed bundle object.'), { category: 'invalid_input', code: 'seed_bundle_file_invalid' });
 		delete input.body.file;
 		input.body.bundle = parsed;
-		if (typeof input.path.name !== 'string' && typeof (parsed as Record<string, unknown>).name === 'string') input.path.name = (parsed as Record<string, unknown>).name;
+		if (operation.descriptor.rest?.path.includes('{name}')
+			&& typeof input.path.name !== 'string'
+			&& typeof (parsed as Record<string, unknown>).name === 'string') {
+			input.path.name = (parsed as Record<string, unknown>).name;
+		}
 	}
 	for (const binding of deferred) if (input[binding.target][binding.field] === undefined) {
 		throw Object.assign(new Error(`Missing required ${binding.source}: ${binding.name}`), { category: 'ambiguous_context', code: `${binding.name}_required` });

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -70,6 +70,7 @@ test('seed commands upload parsed portable bundles instead of API-local paths', 
 			operationInvoke: async (operationId, input) => { invocations.push({ operationId, input }); return { data: { ok: true } }; }, write: () => undefined });
 		assert.equal(exit, 0);
 		assert.equal(invocations[0]?.operationId, 'seeds.validate');
+		assert.deepEqual(invocations[0]?.input.path, {});
 		assert.equal(invocations[0]?.input.body.bundle.schemaVersion, 'treeseed.seed-bundle/v2');
 		assert.equal('file' in invocations[0]?.input.body, false);
 	} finally { rmSync(root, { recursive: true, force: true }); }


### PR DESCRIPTION
Closes #32

## Summary
- derive seed name only for catalog paths that declare {name}
- preserve the empty path contract for seeds.validate
- prepare CLI 0.13.0-rc.8

## Verification
- focused package/command tests: 15/15
- CLI build passes
- live canonical seed validation against accepted API staging succeeds with digest sha256:5c2ca42c74e21523940cf576fb08f4513eb6c21a49ccf23d8b573d945a577b0c and zero diagnostics