### PR TITLE
Supply catalog-required empty request bodies

### DIFF
--- a/src/cli/commands/operator.ts
+++ b/src/cli/commands/operator.ts
@@ -70,7 +70,10 @@ export async function runOperator(invocation: ParsedInvocation, context: Command
 	const { client, profile } = await createControlPlaneClient(invocation, context, operation.descriptor.authentication !== 'anonymous');
 	const options = operation.descriptor.kind === 'mutation' ? { idempotencyKey: randomUUID(), headers: {} as Record<string, string> } : { headers: {} as Record<string, string> };
 	const finalize = async (response: unknown) => {
-		const value = response as Record<string, unknown>;
+		const envelope = response && typeof response === 'object' ? response as Record<string, unknown> : {};
+		const value = envelope.data && typeof envelope.data === 'object'
+			? envelope.data as Record<string, unknown>
+			: envelope;
 		if (operation.descriptor.operationId === 'providers.connect') {
 			const enrollmentToken = typeof value.enrollmentToken === 'string' ? value.enrollmentToken : null;
 			if (!enrollmentToken || !context.providerEnrollmentHandoff) throw Object.assign(new Error('The control plane did not return a usable local provider enrollment handoff.'), { category: 'provider_unavailable', code: 'provider_enrollment_handoff_invalid' });

--- a/src/cli/commands/operator.ts
+++ b/src/cli/commands/operator.ts
@@ -54,7 +54,10 @@ async function operationInput(invocation: ParsedInvocation, context: CommandCont
 	for (const binding of deferred) if (input[binding.target][binding.field] === undefined) {
 		throw Object.assign(new Error(`Missing required ${binding.source}: ${binding.name}`), { category: 'ambiguous_context', code: `${binding.name}_required` });
 	}
-	return { operation, input: { ...input, body: Object.keys(input.body).length ? input.body : undefined } };
+	const body = Object.keys(input.body).length
+		? input.body
+		: operation.schema.body.safeParse(undefined).success ? undefined : {};
+	return { operation, input: { ...input, body } };
 }
 
 export async function runOperator(invocation: ParsedInvocation, context: CommandContext) {

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -105,6 +105,43 @@ test('body-bearing catalog operations receive an empty object when no fields are
 	}]);
 });
 
+test('provider enrollment hands the unwrapped API receipt to trusted local custody', async () => {
+	let requestBody = '';
+	const server = createServer((request, response) => {
+		request.on('data', (chunk) => { requestBody += String(chunk); });
+		request.on('end', () => {
+			response.setHeader('content-type', 'application/json');
+			response.end(JSON.stringify({ data: { teamId: 'team-1', enrollmentToken: 'one-time' } }));
+		});
+	});
+	await new Promise<void>((accept) => server.listen(0, '127.0.0.1', accept));
+	const address = server.address();
+	if (!address || typeof address === 'string') throw new Error('Test server did not bind.');
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-provider-enrollment-'));
+	const env = { TREESEED_CONFIG_HOME: root };
+	try {
+		const profile = { serverId: 'test', label: 'Test', baseUrl: `http://127.0.0.1:${address.port}` };
+		saveServerProfile(profile, env);
+		saveServerSession({ serverId: 'test', audience: profile.baseUrl, accessToken: 'access-token' }, env);
+		const handoffs: Record<string, unknown>[] = [];
+		const output: string[] = [];
+		const exit = await runCommandLine(['providers', 'connect', '--server', 'test', '--team', 'team-1', '--yes', '--json'], {
+			env, interactiveUi: false,
+			providerEnrollmentHandoff: async (input) => { handoffs.push(input); return { requestId: 'request-1' }; },
+			write: (value) => output.push(value),
+		});
+		assert.equal(exit, 0);
+		assert.equal(requestBody, '{}');
+		assert.equal(handoffs[0]?.enrollmentToken, 'one-time');
+		assert.deepEqual(JSON.parse(output[0]!).result, {
+			teamId: 'team-1', connectionState: 'approval_required', provider: { requestId: 'request-1' },
+		});
+	} finally {
+		await new Promise<void>((accept, reject) => server.close((error) => error ? reject(error) : accept()));
+		rmSync(root, { recursive: true, force: true });
+	}
+});
+
 test('unavailable commands fail closed before network or filesystem mutation', async () => {
 	const output: string[] = [];
 	let invocations = 0;

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -91,6 +91,20 @@ test('seed plan derives the path identity from the uploaded portable bundle', as
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('body-bearing catalog operations receive an empty object when no fields are supplied', async () => {
+	const invocations: Array<{ operationId: string; input: any }> = [];
+	const exit = await runCommandLine(['seeds', 'verify', 'treeseed', '--json'], {
+		interactiveUi: false,
+		operationInvoke: async (operationId, input) => { invocations.push({ operationId, input }); return { verified: false }; },
+		write() {},
+	});
+	assert.equal(exit, 0);
+	assert.deepEqual(invocations, [{
+		operationId: 'seeds.verify',
+		input: { path: { name: 'treeseed' }, query: {}, body: {} },
+	}]);
+});
+
 test('unavailable commands fail closed before network or filesystem mutation', async () => {
 	const output: string[] = [];
 	let invocations = 0;


### PR DESCRIPTION
Closes #34

## Summary
- derive empty-body behavior from the authoritative SDK operation schema
- send `{}` when a catalog operation requires a body but the command has no fields
- preserve `undefined` for bodyless read operations

## Verification
- focused canonical command boundary: 13 passed
- CLI build passed
- live `trsd seeds verify treeseed`: successful operation invocation with zero resource drift and an actionable `provider_health_required` closure