### PR TITLE
Adopt SDK RC24 provider bootstrap contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.8",
+  "version": "0.13.0-rc.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.8",
+      "version": "0.13.0-rc.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.22",
+        "@treeseed/sdk": "0.13.0-rc.23",
         "yaml": "2.8.1"
       },
       "bin": {
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.22",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.22.tgz",
-      "integrity": "sha512-bNFCncPrpiY+r7CseA1IEMh4y1vnFnvp6xu+V83OZIum9LH91bTFKu7tWSJcrshxST4eyv6F0XXOoYrqwtNHCQ==",
+      "version": "0.13.0-rc.23",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.23.tgz",
+      "integrity": "sha512-OKswjhRcoPLkYiZ6pONDlSXqhsDkNJVDkRPwgCBaJvaPwdIFGWPBGfVDuADYR4gyJK7CgjbON1mQwntrAowYHg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.0-rc.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.23",
+        "@treeseed/sdk": "0.13.0-rc.24",
         "yaml": "2.8.1"
       },
       "bin": {
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.23",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.23.tgz",
-      "integrity": "sha512-OKswjhRcoPLkYiZ6pONDlSXqhsDkNJVDkRPwgCBaJvaPwdIFGWPBGfVDuADYR4gyJK7CgjbON1mQwntrAowYHg==",
+      "version": "0.13.0-rc.24",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.24.tgz",
+      "integrity": "sha512-ocYAG2EOzxsNMc5Ix/tqMwAlX1THxfISTyT7Tit1F7ORpn1+4HXRXXQg1OM1jE33nMKMPrk0sfDts4cycx+zaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "release:publish": "node --import tsx ./scripts/packages/publish-package.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.23",
+    "@treeseed/sdk": "0.13.0-rc.24",
     "yaml": "2.8.1"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.8",
+  "version": "0.13.0-rc.9",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -49,7 +49,7 @@
     "release:publish": "node --import tsx ./scripts/packages/publish-package.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.22",
+    "@treeseed/sdk": "0.13.0-rc.23",
     "yaml": "2.8.1"
   },
   "overrides": {

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -11,7 +11,7 @@ test('package has one executable and no runtime package dependency', () => {
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
 	assert.equal(pkg.dependencies.ink, undefined);
 	assert.equal(pkg.dependencies.react, undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.22', yaml: '2.8.1' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.24', yaml: '2.8.1' });
 });
 
 test('built package contains executable runtime only', () => {


### PR DESCRIPTION
Closes #36\n\n## Summary\n- pin exact \n- retain the human-centered command tree and local provider enrollment handoff\n- adopt catalog-driven provider mutation idempotency\n\n## Verification\n- 17 focused command-boundary tests passed\n- CLI build passed\n- no live agent, assignment, workday, or content operation started