### PR TITLE
Drain complete CLI JSON output before exit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.9",
+  "version": "0.13.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.9",
+      "version": "0.13.0-rc.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.9",
+  "version": "0.13.0-rc.10",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,4 +6,4 @@ import { fileURLToPath } from 'node:url';
 import { runCommandLine } from './runtime.js';
 
 const executable = (path: string) => { try { return realpathSync(path); } catch { return resolve(path); } };
-if (executable(process.argv[1] ?? '') === executable(fileURLToPath(import.meta.url))) process.exit(await runCommandLine(process.argv.slice(2)));
+if (executable(process.argv[1] ?? '') === executable(fileURLToPath(import.meta.url))) process.exitCode = await runCommandLine(process.argv.slice(2));

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -20,6 +20,12 @@ test('built package contains executable runtime only', () => {
 	assert.equal(readdirSync('dist', { recursive: true }).some((path) => String(path).endsWith('.d.ts')), false);
 });
 
+test('the executable drains complete output before exiting', () => {
+	const main = readFileSync('src/cli/main.ts', 'utf8');
+	assert.equal(main.includes('process.exit('), false);
+	assert.equal(main.includes('process.exitCode = await runCommandLine'), true);
+});
+
 test('source contains no legacy implementation residue', () => {
 	const walk = (root: string): string[] => readdirSync(root, { withFileTypes: true }).flatMap((entry) => entry.isDirectory() ? walk(`${root}/${entry.name}`) : [`${root}/${entry.name}`]);
 	const files = walk('src').join('\n');


### PR DESCRIPTION
Closes #38

## Summary
- replace forced `process.exit()` with `process.exitCode`
- allow stdout and stderr to drain complete machine envelopes
- advance candidate to `0.13.0-rc.10`

## Verification
- CLI build passed
- 18 focused package and command-boundary tests passed
- no governed operation or runtime mutation is introduced