### PR TITLE
Bind host configuration adoption to local socket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.13",
+  "version": "0.13.0-rc.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.13",
+      "version": "0.13.0-rc.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.13",
+  "version": "0.13.0-rc.14",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/host.ts
+++ b/src/cli/commands/host.ts
@@ -14,6 +14,10 @@ function input(invocation: ParsedInvocation) {
 	return { handlerId: invocation.command.execution.handlerId, arguments: invocation.arguments, options };
 }
 
+export function hostUsesProtectedLocalTransport(invocation: Pick<ParsedInvocation, 'command'>) {
+	return invocation.command.name === 'host config adopt' || invocation.command.name === 'host bootstrap enroll';
+}
+
 export async function runHost(invocation: ParsedInvocation, context: CommandContext) {
 	const command = input(invocation);
 	if (invocation.options.plan === true && invocation.command.name === 'host bootstrap enroll') return { action: 'enroll', mutation: false, transport: 'local_socket' };
@@ -25,6 +29,7 @@ export async function runHost(invocation: ParsedInvocation, context: CommandCont
 		return storeHostEnrollment(enrollment, endpoint, context.env);
 	}
 	if (context.hostInvoke) return context.hostInvoke(command);
+	if (hostUsesProtectedLocalTransport(invocation)) return invokeLocalHostManager(command);
 	return invokeHostManager(command, typeof invocation.options.server === 'string' ? invocation.options.server : undefined, context.env);
 }
 import { readFileSync } from 'node:fs';

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -60,6 +60,12 @@ test('host configuration adoption sends validated content and requires explicit 
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('host identity adoption is permanently bound to the protected local socket', async () => {
+	const { hostUsesProtectedLocalTransport } = await import('../../../src/cli/commands/host.ts');
+	assert.equal(hostUsesProtectedLocalTransport({ command: { name: 'host config adopt' } as any }), true);
+	assert.equal(hostUsesProtectedLocalTransport({ command: { name: 'host config apply' } as any }), false);
+});
+
 test('bootstrap enrollment stores credentials privately and never emits key material', async () => {
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-host-')); const output: string[] = [];
 	try {


### PR DESCRIPTION
Host identity adoption is a root-sensitive local-host operation. This change permanently routes it through the protected Unix socket even when a remote host profile or TREESEED_HOST_URL exists. It also advances the CLI to RC14.

Verification: npm run verify:direct; 27 tests pass; packed-install smoke passes.