### PR TITLE
fix: delegate provider enrollment to host manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.16",
+  "version": "0.13.0-rc.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.16",
+      "version": "0.13.0-rc.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.34",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.16",
+  "version": "0.13.0-rc.17",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/support/provider-enrollment.ts
+++ b/src/cli/support/provider-enrollment.ts
@@ -1,8 +1,13 @@
 import { spawn } from 'node:child_process';
+import { invokeLocalHostManager } from './host-client.js';
 
-export async function handoffProviderEnrollment(payload: Record<string, unknown>, env: NodeJS.ProcessEnv) {
+export async function handoffProviderEnrollment(payload: Record<string, unknown>, env: NodeJS.ProcessEnv, localInvoke: (input: unknown) => Promise<unknown> = invokeLocalHostManager) {
 	const executable = env.TREESEED_PROVIDER_ENROLL_EXECUTABLE?.trim();
-	if (!executable) throw Object.assign(new Error('Local provider enrollment handoff is not configured. Set TREESEED_PROVIDER_ENROLL_EXECUTABLE to the trusted provider manager entrypoint.'), { category: 'provider_unavailable', code: 'provider_enrollment_handoff_unavailable' });
+	if (!executable) return localInvoke({
+		handlerId: 'local.host.provider.enrollment',
+		arguments: [],
+		options: { payload: JSON.stringify(payload) },
+	}) as Promise<Record<string, unknown>>;
 	let args: string[] = [];
 	if (env.TREESEED_PROVIDER_ENROLL_ARGUMENTS) {
 		const parsed = JSON.parse(env.TREESEED_PROVIDER_ENROLL_ARGUMENTS);

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -7,6 +7,7 @@ import test from 'node:test';
 import { listCommandPaths, TREESEED_COMMAND_TREE_V1 } from '@treeseed/sdk/operator-contracts';
 import { commandSpecs } from '../../../src/cli/registry.ts';
 import { runCommandLine } from '../../../src/cli/runtime.ts';
+import { handoffProviderEnrollment } from '../../../src/cli/support/provider-enrollment.ts';
 import { loadServerSession, saveServerProfile, saveServerSession } from '../../../src/cli/support/server-custody.ts';
 
 test('registry exactly matches the SDK command tree', () => {
@@ -202,6 +203,16 @@ test('provider enrollment hands the unwrapped API receipt to trusted local custo
 		await new Promise<void>((accept, reject) => server.close((error) => error ? reject(error) : accept()));
 		rmSync(root, { recursive: true, force: true });
 	}
+});
+
+test('provider enrollment defaults to the protected local manager socket contract', async () => {
+	const requests: unknown[] = [];
+	const result = await handoffProviderEnrollment({ action: 'complete', connectionId: 'local-team' }, {}, async (input) => {
+		requests.push(input);
+		return { connectionId: 'local-team', state: 'connected' };
+	});
+	assert.deepEqual(requests, [{ handlerId: 'local.host.provider.enrollment', arguments: [], options: { payload: '{"action":"complete","connectionId":"local-team"}' } }]);
+	assert.deepEqual(result, { connectionId: 'local-team', state: 'connected' });
 });
 
 test('unavailable commands fail closed before network or filesystem mutation', async () => {


### PR DESCRIPTION
## Outcome

`trsd providers connect` and approval completion default to the protected local host-manager socket; operators no longer configure a Docker enrollment executable.

## Work authority

- Work item / Issue: Unified TreeSeed fresh-seed provider checkpoint
- Proposal / decision: User-directed completion in the Unified TreeSeed task
- Assignment / checkpoint: Device authorization and provider enrollment checkpoint
- Actor: Codex
- Human authority: adrianwebb
- Agent / capacity provider: Codex / provider_n2oUoC09G62vo8BnIi7r0eeTYyBi34xu
- Exact base ref: staging 8b5ed2ef9fd254127f2a90fc93cd1fe52fe02cb4
- Exact head ref: codex/provider-enrollment-handoff-rc17 06242ee771024e25b783a1ecccf007227bd93d14

Contributor mode (select one):

- [ ] Human-authored
- [ ] Agent-assisted under human authority
- [x] Agent-authored under human authority

## Plan

Delegate the existing enrollment receipt to the locally protected manager contract while preserving the explicit executable override for controlled testing.

## Changes and commits

- Default provider enrollment custody to `local.host.provider.enrollment`.
- Add contract coverage for exact request shape.
- Advance CLI to 0.13.0-rc.17.
- Commit: 06242ee771024e25b783a1ecccf007227bd93d14

## Verification

`npm run verify:direct` passed: release verification, 31 tests, built executable smoke, and packed artifact.

## Risk and rollback

Risk is limited to provider enrollment handoff. Existing explicit handoff override remains usable for tests. Roll back by reverting the exact commit and republishing the prior CLI artifact.

## Completion summary

Ready for staging and RC publication; Deployment RC43 supplies the receiving manager operation.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.