### PR TITLE
Fix authentication command termination and confirmations

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -30,9 +30,9 @@ Operation: mutation. Result schema: `treeseed.command.login/v1`.
 Execution: `protocol.oauth.device.login`.
 
 - `--server <value>`: Control-plane server profile or URL.
-- `--yes`: Confirm authorized automation.
 - `--json`: Emit the stable JSON envelope.
 - `--plan`: Return the exact proposed outcome without mutation.
+- `--timeout <value>`: Maximum seconds to wait for device authorization.
 
 ### trsd auth logout
 
@@ -67,12 +67,12 @@ Operation: mutation. Result schema: `treeseed.command.create/v1`.
 Execution: `protocol.accounts.create`.
 
 - `--server <value>`: Control-plane server profile or URL.
-- `--yes`: Confirm authorized automation.
 - `--json`: Emit the stable JSON envelope.
 - `--plan`: Return the exact proposed outcome without mutation.
 - `--email <value>`: Email address for the new user.
 - `--username <value>`: Unique username for the new user.
 - `--display-name <value>`: Human-readable display name.
+- `--timeout <value>`: Maximum seconds to wait for registration.
 
 ## trsd secrets
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.18",
+  "version": "0.13.0-rc.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.18",
+      "version": "0.13.0-rc.19",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.35",
+        "@treeseed/sdk": "0.13.0-rc.36",
         "yaml": "2.8.1"
       },
       "bin": {
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.35",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.35.tgz",
-      "integrity": "sha512-ke0zGJXNsww0HhcEg3uI43WNUmMGiyfmcOhfKpnTHVmDrtt6BEjAU4McPCo6YjKrMnq+KWWRY+6PmwJ/oZvqJw==",
+      "version": "0.13.0-rc.36",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.36.tgz",
+      "integrity": "sha512-fWZdSvM/mAD+iXCGGcGEXBpDJBGg3eiW/QU1w9hVygvFD6nj1gHBF4ZKdLIblpzbcm6jAj+c69bq3lxa7mEfTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.18",
+  "version": "0.13.0-rc.19",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -49,7 +49,7 @@
     "release:publish": "node --import tsx ./scripts/packages/publish-package.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.35",
+    "@treeseed/sdk": "0.13.0-rc.36",
     "yaml": "2.8.1"
   },
   "overrides": {

--- a/schemas/command-tree.json
+++ b/schemas/command-tree.json
@@ -135,11 +135,16 @@
               "name": "--plan",
               "description": "Return the exact proposed outcome without mutation.",
               "type": "boolean"
+            },
+            {
+              "name": "--timeout",
+              "description": "Maximum seconds to wait for device authorization.",
+              "type": "number"
             }
           ],
           "authorization": {
             "capability": "command.login",
-            "confirmation": "credential"
+            "confirmation": "never"
           },
           "resultSchemaId": "treeseed.command.login/v1",
           "execution": {
@@ -213,11 +218,16 @@
               "name": "--display-name",
               "description": "Human-readable display name.",
               "type": "string"
+            },
+            {
+              "name": "--timeout",
+              "description": "Maximum seconds to wait for registration.",
+              "type": "number"
             }
           ],
           "authorization": {
             "capability": "command.create",
-            "confirmation": "credential"
+            "confirmation": "never"
           },
           "resultSchemaId": "treeseed.command.create/v1",
           "execution": {

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -7,6 +7,15 @@ import { CONTROL_PLANE_CLI_CLIENT_ID, createControlPlaneClient } from '../suppor
 import { clearServerSession, saveServerProfile, saveServerSession } from '../support/server-custody.js';
 
 const DEFAULT_SCOPES: OAuthScope[] = ['treeseed:read', 'treeseed:knowledge:write', 'treeseed:governance:write', 'treeseed:projects:write', 'treeseed:execution'];
+const DEFAULT_LOGIN_TIMEOUT_SECONDS = 300;
+
+function configuredLoginTimeoutSeconds(invocation: ParsedInvocation, context: CommandContext) {
+	const configured = invocation.options.timeout ?? context.env.TREESEED_CLI_LOGIN_TIMEOUT_SECONDS
+		?? context.env.TREESEED_CLI_OPERATION_TIMEOUT_SECONDS ?? DEFAULT_LOGIN_TIMEOUT_SECONDS;
+	const value = Number(configured);
+	if (!Number.isFinite(value) || value <= 0 || value > 3_600) throw Object.assign(new Error('--timeout must be between 1 and 3600 seconds.'), { category: 'invalid_input', code: 'invalid_timeout' });
+	return value;
+}
 
 function pollingState(error: unknown) {
 	if (!(error instanceof ControlPlaneClientError)) return 'failed' as const;
@@ -18,9 +27,11 @@ function pollingState(error: unknown) {
 export async function runAuth(invocation: ParsedInvocation, context: CommandContext) {
 	const { profile, session, client } = await createControlPlaneClient(invocation, context, false);
 	if (invocation.command.name === 'auth login') {
-		const authorization = await client.authorizeDevice(CONTROL_PLANE_CLI_CLIENT_ID, DEFAULT_SCOPES);
+		const configuredTimeout = configuredLoginTimeoutSeconds(invocation, context);
+		const authorization = await client.authorizeDevice(CONTROL_PLANE_CLI_CLIENT_ID, DEFAULT_SCOPES, AbortSignal.timeout(configuredTimeout * 1_000));
 		context.write(`Open ${authorization.verificationUriComplete ?? authorization.verificationUri} and enter code ${authorization.userCode}.`, 'stderr');
-		const deadline = Date.now() + authorization.expiresIn * 1_000;
+		const timeoutSeconds = Math.min(configuredTimeout, authorization.expiresIn);
+		const deadline = Date.now() + timeoutSeconds * 1_000;
 		let interval = Math.max(1, authorization.interval) * 1_000;
 		while (Date.now() < deadline) {
 			try {
@@ -37,10 +48,10 @@ export async function runAuth(invocation: ParsedInvocation, context: CommandCont
 				const state = pollingState(error);
 				if (state === 'failed') throw error;
 				if (state === 'slow_down') interval += 5_000;
-				await delay(interval);
+				await delay(Math.min(interval, Math.max(1, deadline - Date.now())));
 			}
 		}
-		throw Object.assign(new Error('Device authorization expired before approval.'), { category: 'authentication_required', code: 'device_authorization_expired' });
+		throw Object.assign(new Error(`Device authorization was not approved within ${timeoutSeconds} seconds.`), { category: 'authentication_required', code: 'device_authorization_timeout' });
 	}
 	if (invocation.command.name === 'auth logout') {
 		const token = session?.refreshToken ?? session?.accessToken;

--- a/src/cli/commands/users.ts
+++ b/src/cli/commands/users.ts
@@ -4,6 +4,8 @@ import type { CommandContext, ParsedInvocation } from '../types.js';
 import { createControlPlaneClient } from '../support/client.js';
 import { promptHidden } from '../support/prompts.js';
 
+const DEFAULT_REGISTRATION_TIMEOUT_SECONDS = 30;
+
 function requiredOption(invocation: ParsedInvocation, name: string) {
 	const value = invocation.options[name];
 	if (typeof value !== 'string' || !value.trim()) throw Object.assign(new Error(`--${name.replace(/[A-Z]/gu, (letter) => `-${letter.toLowerCase()}`)} is required.`), { category: 'invalid_input', code: `${name}_required` });
@@ -16,11 +18,41 @@ async function secret(context: CommandContext, question: string) {
 	return promptHidden(question);
 }
 
+function timeoutSeconds(invocation: ParsedInvocation, context: CommandContext) {
+	const configured = invocation.options.timeout ?? context.env.TREESEED_CLI_USER_CREATE_TIMEOUT_SECONDS
+		?? context.env.TREESEED_CLI_OPERATION_TIMEOUT_SECONDS ?? DEFAULT_REGISTRATION_TIMEOUT_SECONDS;
+	const value = Number(configured);
+	if (!Number.isFinite(value) || value <= 0 || value > 600) throw Object.assign(new Error('--timeout must be between 1 and 600 seconds.'), { category: 'invalid_input', code: 'invalid_timeout' });
+	return value;
+}
+
+async function registrationWithin<T>(seconds: number, operation: (signal: AbortSignal) => Promise<T>) {
+	const controller = new AbortController();
+	let timedOut = false;
+	let timer: NodeJS.Timeout;
+	const timeout = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => {
+			timedOut = true;
+			controller.abort();
+			reject(new Error('registration_timeout'));
+		}, seconds * 1_000);
+	});
+	try {
+		return await Promise.race([operation(controller.signal), timeout]);
+	} catch (error) {
+		if (timedOut) throw Object.assign(new Error(`User creation timed out after ${seconds} seconds.`), { category: 'provider_unavailable', code: 'user_creation_timeout' });
+		throw error;
+	} finally {
+		clearTimeout(timer!);
+	}
+}
+
 export async function runUsers(invocation: ParsedInvocation, context: CommandContext) {
 	if (invocation.command.name !== 'users create') throw Object.assign(new Error(`No user handler is installed for ${invocation.command.name}.`), { category: 'policy_blocked', code: 'local_handler_unavailable' });
 	const email = requiredOption(invocation, 'email');
 	const username = requiredOption(invocation, 'username');
 	const displayName = requiredOption(invocation, 'displayName');
+	const timeout = timeoutSeconds(invocation, context);
 	if (invocation.options.plan === true) return { operationId: 'accounts.register', input: { email, username, displayName, passwordSource: 'interactive-secret-prompt' }, mutation: false };
 	let password = await secret(context, 'New TreeSeed password: ');
 	let confirmation = await secret(context, 'Repeat password: ');
@@ -28,9 +60,9 @@ export async function runUsers(invocation: ParsedInvocation, context: CommandCon
 		if (password !== confirmation) throw Object.assign(new Error('Passwords do not match.'), { category: 'invalid_input', code: 'password_mismatch' });
 		if (password.length < 12) throw Object.assign(new Error('Password must be at least 12 characters.'), { category: 'invalid_input', code: 'invalid_password' });
 		const input = { path: {}, query: {}, body: { email, username, displayName, password } };
-		const response = context.operationInvoke
-			? await context.operationInvoke('accounts.register', input)
-			: await invokeRegistration(invocation, context, input);
+		const response = await registrationWithin(timeout, (signal) => context.operationInvoke
+			? context.operationInvoke('accounts.register', input)
+			: invokeRegistration(invocation, context, input, signal));
 		const envelope = response && typeof response === 'object' ? response as Record<string, unknown> : {};
 		const result = envelope.data && typeof envelope.data === 'object' ? envelope.data as Record<string, unknown> : envelope;
 		return { ...result, nextAction: 'Open https://mail.treeseed.localhost and confirm the new account, then run trsd auth login.' };
@@ -40,8 +72,8 @@ export async function runUsers(invocation: ParsedInvocation, context: CommandCon
 	}
 }
 
-async function invokeRegistration(invocation: ParsedInvocation, context: CommandContext, input: { path: {}; query: {}; body: { email: string; username: string; displayName: string; password: string } }) {
+async function invokeRegistration(invocation: ParsedInvocation, context: CommandContext, input: { path: {}; query: {}; body: { email: string; username: string; displayName: string; password: string } }, signal: AbortSignal) {
 	const operation = controlPlaneOperation('accounts.register');
 	const { client } = await createControlPlaneClient(invocation, context, false);
-	return client.invoke(operation, input, { idempotencyKey: randomUUID(), headers: {} });
+	return client.invoke(operation, input, { idempotencyKey: randomUUID(), headers: {}, signal });
 }

--- a/src/cli/support/human-renderer.ts
+++ b/src/cli/support/human-renderer.ts
@@ -63,6 +63,11 @@ export function renderHumanCommandResult(value: unknown) {
 			Array.isArray(result.scopes) ? `Scopes: ${result.scopes.map(scalar).join(', ')}` : ''].filter(Boolean).join('\n');
 	}
 	if (path === 'auth logout' && result) return `Logged out of ${scalar(result.serverId)}.`;
+	if (path === 'users create' && result) return [
+		`User registration accepted for ${scalar(result.email)}.`,
+		result.confirmationRequired ? 'Email confirmation is required before login.' : 'The user is ready to log in.',
+		result.nextAction ? `Next: ${scalar(result.nextAction)}` : '',
+	].filter(Boolean).join('\n');
 	if (path === 'auth status' && result) {
 		const name = principalName(result.principal);
 		const teams = Array.isArray(result.teams) ? result.teams.length : 0;

--- a/src/cli/support/prompts.ts
+++ b/src/cli/support/prompts.ts
@@ -13,7 +13,7 @@ export function promptHidden(question: string) {
 	return new Promise<string>((resolvePromise, reject) => {
 		if (!stdin.isTTY || !stdout.isTTY) { reject(new Error('Secret input requires an interactive TTY.')); return; }
 		let value = '';
-		const cleanup = () => { stdin.removeListener('data', onData); stdin.setRawMode(false); stdout.write('\n'); };
+		const cleanup = () => { stdin.removeListener('data', onData); stdin.setRawMode(false); stdin.pause(); stdout.write('\n'); };
 		const onData = (chunk: Buffer | string) => {
 			for (const char of String(chunk)) {
 				if (char === '\n' || char === '\r') { cleanup(); resolvePromise(value); return; }

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -11,7 +11,7 @@ test('package has one executable and no runtime package dependency', () => {
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
 	assert.equal(pkg.dependencies.ink, undefined);
 	assert.equal(pkg.dependencies.react, undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.35', yaml: '2.8.1' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.36', yaml: '2.8.1' });
 });
 
 test('built package contains executable runtime only', () => {

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -331,7 +331,7 @@ test('JSON device login keeps human approval instructions off stdout', async () 
 	const output: Array<{ value: string; stream?: string }> = [];
 	try {
 		saveServerProfile({ serverId: 'test', label: 'Test', baseUrl }, { TREESEED_CONFIG_HOME: root });
-		const exit = await runCommandLine(['auth', 'login', '--server', 'test', '--yes', '--json'], {
+		const exit = await runCommandLine(['auth', 'login', '--server', 'test', '--json'], {
 			env: { TREESEED_CONFIG_HOME: root }, interactiveUi: false,
 			write: (value, stream) => output.push({ value, stream }),
 		});

--- a/tests/unit/command-boundary/users-create.test.ts
+++ b/tests/unit/command-boundary/users-create.test.ts
@@ -8,7 +8,7 @@ test('users create securely prompts twice and invokes the anonymous registration
 	const output: string[] = [];
 	const prompts = ['a sufficiently long password', 'a sufficiently long password'];
 	const calls: Array<{ operationId: string; input: any }> = [];
-	const exit = await runCommandLine([...identity, '--yes', '--json'], {
+	const exit = await runCommandLine([...identity, '--json'], {
 		interactiveUi: false,
 		promptSecret: async () => prompts.shift() ?? '',
 		operationInvoke: async (operationId, input) => {
@@ -43,11 +43,24 @@ test('users create plan never prompts or exposes a password', async () => {
 	assert.equal('password' in result.input, false);
 });
 
+test('users create prints an explicit success result in human mode', async () => {
+	const output: string[] = [];
+	const prompts = ['a sufficiently long password', 'a sufficiently long password'];
+	const exit = await runCommandLine(identity, {
+		interactiveUi: false,
+		promptSecret: async () => prompts.shift() ?? '',
+		operationInvoke: async () => ({ data: { confirmationRequired: true, email: 'adrian.webb@knowledge.coop' } }),
+		write: (value) => output.push(value),
+	});
+	assert.equal(exit, 0);
+	assert.match(output[0]!, /User registration accepted for adrian\.webb@knowledge\.coop\./u);
+});
+
 test('users create rejects mismatched passwords without invoking the API or leaking either value', async () => {
 	const output: string[] = [];
 	const prompts = ['first secret value', 'second secret value'];
 	let invocations = 0;
-	const exit = await runCommandLine([...identity, '--yes', '--json'], {
+	const exit = await runCommandLine([...identity, '--json'], {
 		interactiveUi: false,
 		promptSecret: async () => prompts.shift() ?? '',
 		operationInvoke: async () => { invocations += 1; },
@@ -57,4 +70,17 @@ test('users create rejects mismatched passwords without invoking the API or leak
 	assert.equal(invocations, 0);
 	assert.equal(JSON.parse(output[0]!).error.code, 'password_mismatch');
 	assert.doesNotMatch(output[0]!, /first secret|second secret/u);
+});
+
+test('users create fails deterministically when registration exceeds the configured timeout', async () => {
+	const output: string[] = [];
+	const prompts = ['a sufficiently long password', 'a sufficiently long password'];
+	const exit = await runCommandLine([...identity, '--timeout', '1', '--json'], {
+		interactiveUi: false,
+		promptSecret: async () => prompts.shift() ?? '',
+		operationInvoke: async () => new Promise(() => undefined),
+		write: (value) => output.push(value),
+	});
+	assert.equal(exit, 1);
+	assert.equal(JSON.parse(output[0]!).error.code, 'user_creation_timeout');
 });


### PR DESCRIPTION
Stops secret input from holding stdin open, adds configurable registration/login timeouts, removes redundant confirmation prompts, emits explicit registration success, consumes SDK RC36, and prepares CLI RC19.