### PR TITLE
fix: verify portable seed bundles by path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.19",
+  "version": "0.13.0-rc.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.19",
+      "version": "0.13.0-rc.20",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.36",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.19",
+  "version": "0.13.0-rc.20",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/operator.ts
+++ b/src/cli/commands/operator.ts
@@ -29,6 +29,17 @@ function transform(value: unknown, binding: CommandInputBinding) {
 	return value;
 }
 
+async function portableSeedBundle(fileValue: string, context: CommandContext) {
+	const file = resolve(context.cwd, fileValue);
+	const parsed = parseYaml(await readFile(file, 'utf8'));
+	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw Object.assign(new Error('Seed file must contain one portable seed bundle object.'), { category: 'invalid_input', code: 'seed_bundle_file_invalid' });
+	return parsed as Record<string, unknown>;
+}
+
+function looksLikeSeedFile(value: string) {
+	return /(?:^|[/\\])[^/\\]+\.(?:json|ya?ml)$/iu.test(value);
+}
+
 async function operationInput(invocation: ParsedInvocation, context: CommandContext) {
 	if (invocation.command.execution.kind !== 'operation') throw new Error('Command is not operation-bound.');
 	const input = { path: {} as Record<string, unknown>, query: {} as Record<string, unknown>, body: {} as Record<string, unknown> };
@@ -40,9 +51,7 @@ async function operationInput(invocation: ParsedInvocation, context: CommandCont
 	}
 	const operation = controlPlaneOperation(invocation.command.execution.operationId);
 	if (operation.descriptor.operationId.startsWith('seeds.') && typeof input.body.file === 'string') {
-		const file = resolve(context.cwd, input.body.file);
-		const parsed = parseYaml(await readFile(file, 'utf8'));
-		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw Object.assign(new Error('Seed file must contain one portable seed bundle object.'), { category: 'invalid_input', code: 'seed_bundle_file_invalid' });
+		const parsed = await portableSeedBundle(input.body.file, context);
 		delete input.body.file;
 		input.body.bundle = parsed;
 		if (operation.descriptor.rest?.path.includes('{name}')
@@ -50,6 +59,14 @@ async function operationInput(invocation: ParsedInvocation, context: CommandCont
 			&& typeof (parsed as Record<string, unknown>).name === 'string') {
 			input.path.name = (parsed as Record<string, unknown>).name;
 		}
+	}
+	if (operation.descriptor.operationId === 'seeds.verify'
+		&& typeof input.path.name === 'string'
+		&& looksLikeSeedFile(input.path.name)) {
+		const parsed = await portableSeedBundle(input.path.name, context);
+		if (typeof parsed.name !== 'string' || !parsed.name.trim()) throw Object.assign(new Error('Seed file must declare a name.'), { category: 'invalid_input', code: 'seed_bundle_name_required' });
+		input.path.name = parsed.name;
+		input.body.bundle = parsed;
 	}
 	if (!operation.descriptor.operationId.startsWith('seeds.') && typeof input.body.file === 'string') {
 		const file = resolve(context.cwd, input.body.file);

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -185,6 +185,25 @@ test('body-bearing catalog operations receive an empty object when no fields are
 	}]);
 });
 
+test('seed verify accepts a portable bundle path and derives its seed identity', async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-seed-verify-'));
+	const file = resolve(root, 'treeseed.yaml');
+	writeFileSync(file, `schemaVersion: treeseed.seed-bundle/v3\nname: treeseed\nversion: 1\ndescription: test\nenvironments: [local]\ndigest: sha256:${'0'.repeat(64)}\nresources:\n  teams: []\n  memberships: []\n  projects: []\n  repositories: []\nruntime:\n  capacityProviders: []\n`);
+	const invocations: Array<{ operationId: string; input: any }> = [];
+	try {
+		const exit = await runCommandLine(['seeds', 'verify', file, '--json'], {
+			interactiveUi: false,
+			operationInvoke: async (operationId, input) => { invocations.push({ operationId, input }); return { verified: true }; },
+			write() {},
+		});
+		assert.equal(exit, 0);
+		assert.equal(invocations.length, 1);
+		assert.equal(invocations[0]?.operationId, 'seeds.verify');
+		assert.equal(invocations[0]?.input.path.name, 'treeseed');
+		assert.equal(invocations[0]?.input.body.bundle.name, 'treeseed');
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('provider enrollment hands the unwrapped API receipt to trusted local custody', async () => {
 	let requestBody = '';
 	const server = createServer((request, response) => {


### PR DESCRIPTION
## Summary
- accept a portable YAML/JSON bundle path in seeds verify
- derive the API seed identity from the bundle
- preserve name-based retained-bundle verification
- release CLI 0.13.0-rc.20

## Verification
- npm run verify:direct
- 35 CLI tests passed