### PR TITLE
fix: report library index at configured ref

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.20",
+  "version": "0.13.0-rc.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.20",
+      "version": "0.13.0-rc.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.36",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.20",
+  "version": "0.13.0-rc.21",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/library.ts
+++ b/src/cli/commands/library.ts
@@ -42,17 +42,17 @@ export async function runLibrary(invocation: ParsedInvocation, context: CommandC
 	const library = data(libraryResponse);
 	const repoId = text(library.repositoryId);
 	if (!repoId) throw Object.assign(new Error('The project library has no TreeDX repository binding.'), { category: 'provider_unavailable', code: 'library_binding_unavailable' });
+	const ref = text(invocation.options.ref) ?? text(library.contentRepositoryRef) ?? 'refs/heads/staging';
 	const command = invocation.command.path[1];
 	if (command === 'show') return { project: matches[0], library };
 	if (command === 'status') {
 		const [repository, status, index] = await Promise.all([
 			invoke('treedx.repositories.show', { path: { projectId, repoId }, query: {} }),
 			invoke('treedx.repositories.status', { path: { projectId, repoId }, query: {} }),
-			invoke('treedx.repositories.search.index.status', { path: { projectId, repoId }, query: {} }),
+			invoke('treedx.repositories.search.index.status', { path: { projectId, repoId }, query: { ref } }),
 		]);
 		return { project: matches[0], library, repository: data(repository), status: data(status), searchIndex: data(index) };
 	}
-	const ref = text(invocation.options.ref) ?? text(library.contentRepositoryRef) ?? 'refs/heads/staging';
 	if (command === 'paths') {
 		const prefix = text(invocation.options.prefix)?.replace(/^\/+|\/+$/gu, '');
 		return invoke('treedx.repositories.paths.list', { path: { projectId, repoId }, query: {}, body: { ref, paths: [prefix ? `${prefix}/**` : '**'], kinds: ['blob'], limit: number(invocation.options.limit) ?? 100, ...(text(invocation.options.cursor) ? { cursor: text(invocation.options.cursor) } : {}) } });

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -140,6 +140,22 @@ test('library commands resolve project slugs and the bound TreeDX repository', a
 	assert.equal(JSON.parse(output[0]!).result.files[0].path, 'agents/guide-steward.md');
 });
 
+test('library status checks the search index at the configured library ref', async () => {
+	const invocations: Array<{ operationId: string; input: any }> = []; const output: string[] = [];
+	const exit = await runCommandLine(['library', 'status', 'sdk', '--json'], {
+		interactiveUi: false,
+		operationInvoke: async (operationId, input) => {
+			invocations.push({ operationId, input });
+			if (operationId === 'projects.list') return { data: { items: [{ id: 'project-sdk', slug: 'sdk', name: 'SDK' }] } };
+			if (operationId === 'treedx.library.show') return { data: { repositoryId: 'repo-sdk', contentRepositoryRef: 'refs/remotes/origin/staging', contentPath: '.' } };
+			return { data: { ok: true } };
+		}, write: (value) => output.push(value),
+	});
+	assert.equal(exit, 0);
+	const index = invocations.find((entry) => entry.operationId === 'treedx.repositories.search.index.status');
+	assert.deepEqual(index?.input.query, { ref: 'refs/remotes/origin/staging' });
+});
+
 test('seed commands upload parsed portable bundles instead of API-local paths', async () => {
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-seed-'));
 	const file = resolve(root, 'treeseed.yaml');


### PR DESCRIPTION
## Summary
- resolve the configured library ref before status checks
- query TreeDX search-index health at that exact ref
- cover staging-ref status behavior

## Verification
- npm test (36 passing)