### PR TITLE
Make development runtimes container-portable

### DIFF
--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, readdirSync, renameSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
-import { basename, dirname, isAbsolute, resolve } from 'node:path';
+import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { developmentCandidateSchema, developmentRuntimeSchema, type DevelopmentRuntime, type DevelopmentTarget } from '@treeseed/sdk/development';
 import { parse as parseYaml } from 'yaml';
@@ -100,6 +100,16 @@ function operationForMode(target: DevelopmentTarget, mode: string) {
 	return target.operations.start ?? null;
 }
 
+export function developmentOperationEnvironment(state: Pick<LocalSessionState, 'manifest' | 'sessionId'>, worktree: string, mode: string, env: NodeJS.ProcessEnv, resolvedEnvironment: NodeJS.ProcessEnv = {}, operationEnvironment: NodeJS.ProcessEnv = {}) {
+	return { ...env, ...resolvedEnvironment, TREESEED_DEVELOPMENT_SESSION_ID: state.sessionId, TREESEED_DEVELOPMENT_MODE: mode, TREESEED_DEVELOPMENT_WORKSPACE_ROOT: dirname(state.manifest), TREESEED_DEVELOPMENT_WORKTREE: worktree, ...operationEnvironment };
+}
+
+function runOneShotOperation(state: LocalSessionState, operation: NonNullable<DevelopmentTarget['operations']['setup']>, worktree: string, mode: string, env: NodeJS.ProcessEnv, resolvedEnvironment: NodeJS.ProcessEnv = {}) {
+	const root = operation.cwd ? resolve(worktree, operation.cwd) : worktree;
+	const result = spawnSync(operation.command, operation.args, { cwd: root, env: developmentOperationEnvironment(state, worktree, mode, env, resolvedEnvironment, operation.environment), stdio: 'inherit', timeout: operation.timeoutSeconds * 1_000 });
+	if (result.status !== 0) throw new Error(`Development operation failed: ${operation.command} ${operation.args.join(' ')}.`);
+}
+
 function startOperation(state: LocalSessionState, runtime: DevelopmentRuntime, target: DevelopmentTarget, worktree: string, mode: string, env: NodeJS.ProcessEnv, resolvedEnvironment: NodeJS.ProcessEnv = {}) {
 	const operation = operationForMode(target, mode);
 	if (!operation) return null;
@@ -111,7 +121,7 @@ function startOperation(state: LocalSessionState, runtime: DevelopmentRuntime, t
 	mkdirSync(dirname(log), { recursive: true, mode: 0o700 });
 	const descriptor = openSync(log, 'a', 0o600);
 	try {
-		const child = spawn(operation.command, operation.args, { cwd: root, env: { ...env, ...resolvedEnvironment, ...operation.environment, TREESEED_DEVELOPMENT_SESSION_ID: state.sessionId, TREESEED_DEVELOPMENT_MODE: mode }, detached: true, stdio: ['ignore', descriptor, descriptor] });
+		const child = spawn(operation.command, operation.args, { cwd: root, env: developmentOperationEnvironment(state, worktree, mode, env, resolvedEnvironment, operation.environment), detached: true, stdio: ['ignore', descriptor, descriptor] });
 		child.unref(); if (!child.pid) throw new Error(`Failed to start ${key}.`);
 		return state.processes[key] = { pid: child.pid, projectId: runtime.project.id, targetId: target.id, log };
 	} finally { closeSync(descriptor); }
@@ -139,6 +149,7 @@ async function stopProcesses(state: LocalSessionState) {
 	while (Date.now() < deadline && running.some((processState) => { try { process.kill(processState.pid, 0); return true; } catch { return false; } })) await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
 	for (const processState of running) { try { process.kill(-processState.pid, 'SIGKILL'); } catch { /* process exited during the grace period */ } }
 	state.processes = {};
+	return running;
 }
 
 function restoreOverlays(state: LocalSessionState, projectId?: string, removeGenerations = true) {
@@ -179,8 +190,12 @@ function installPackageOverlay(state: LocalSessionState, record: { session: { re
 		if (existsSync(backup)) throw new Error(`Stale development overlay backup blocks ${link}.`);
 		let retained: string | null = null;
 		try { lstatSync(link); renameSync(link, backup); retained = backup; } catch (error) { if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error; }
-		symlinkSync(resolve(overlayRoot, 'current'), link, 'dir'); state.overlays.push({ projectId: runtime.project.id, packageName, link, backup: retained, overlayRoot });
+		symlinkSync(relativeOverlayTarget(link, overlayRoot), link, 'dir'); state.overlays.push({ projectId: runtime.project.id, packageName, link, backup: retained, overlayRoot });
 	}
+}
+
+export function relativeOverlayTarget(link: string, overlayRoot: string) {
+	return relative(dirname(link), resolve(overlayRoot, 'current'));
 }
 
 function startPackageSynchronizer(state: LocalSessionState, runtime: DevelopmentRuntime, target: DevelopmentTarget, worktree: string, env: NodeJS.ProcessEnv) {
@@ -238,10 +253,15 @@ async function useTargets(invocation: ParsedInvocation, context: CommandContext)
 		if (!repository) throw new Error(`No worktree is registered for ${selection.projectId}.`);
 		if (selection.mode === 'released') {
 			const processState = state.processes[`${selection.projectId}.${selection.targetId}`];
-			if (processState) { try { process.kill(-processState.pid, 'SIGTERM'); } catch { /* already stopped */ } delete state.processes[`${selection.projectId}.${selection.targetId}`]; }
+			if (processState) {
+				await stopProcesses({ ...state, processes: { [`${selection.projectId}.${selection.targetId}`]: processState } });
+				delete state.processes[`${selection.projectId}.${selection.targetId}`];
+			}
+			if (target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, repository.worktree, selection.mode, context.env);
 			restoreOverlays(state, selection.projectId);
 		} else {
 			const resolved = await invoke(context, 'local.dev.environment', { sessionId, projectId: selection.projectId, targetId: selection.targetId }) as { environment?: NodeJS.ProcessEnv };
+			if (target.operations.setup) runOneShotOperation(state, target.operations.setup, repository.worktree, selection.mode, context.env, resolved.environment ?? {});
 			startOperation(state, runtime, target, repository.worktree, selection.mode, context.env, resolved.environment ?? {});
 			saveState(state, context.env);
 			if (target.kind === 'package-watch') {
@@ -307,7 +327,10 @@ export async function runDevelopment(invocation: ParsedInvocation, context: Comm
 	const state = loadState(context.env), sessionId = String(invocation.options.session ?? state.sessionId);
 	if (invocation.command.name === 'dev session stop') {
 		if (invocation.options.plan === true) return { sessionId, restore: true, mutation: false };
-		await stopProcesses(state); restoreOverlays(state); saveState(state, context.env); return invoke(context, 'local.dev.session.stop', { sessionId });
+		const running = await stopProcesses(state);
+		const active = new Set(running.map((entry) => `${entry.projectId}.${entry.targetId}`));
+		for (const { selection, runtime } of loadRuntimes(state.manifest)) for (const target of runtime.targets) if (active.has(`${runtime.project.id}.${target.id}`) && target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, selection.worktree!, 'released', context.env);
+		restoreOverlays(state); saveState(state, context.env); return invoke(context, 'local.dev.session.stop', { sessionId });
 	}
 	if (invocation.command.name === 'dev status') return invoke(context, 'local.dev.status', { ...(invocation.options.session ? { sessionId } : {}), all: invocation.options.all === true });
 	if (invocation.command.name === 'dev plan') return invoke(context, 'local.dev.plan', { sessionId, selected: [] });

--- a/tests/unit/command-boundary/development-session.test.ts
+++ b/tests/unit/command-boundary/development-session.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import test from 'node:test';
 import { runCommandLine } from '../../../src/cli/runtime.ts';
+import { developmentOperationEnvironment, relativeOverlayTarget } from '../../../src/cli/commands/development.ts';
 
 const manifest = `schemaVersion: treeseed.package/v1
 development:
@@ -60,4 +61,18 @@ test('development session start uses one protected manager command and private l
 		const payload = JSON.parse((calls[0] as { options: { payload: string } }).options.payload);
 		assert.equal(payload.runtimes[0].project.id, 'admin'); assert.equal(payload.session.targets[0].mode, 'released');
 	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('development operations receive portable workspace identity and overlays use relative links', () => {
+	const state = { manifest: '/workspace/development.session.yaml', sessionId: 'session-1' };
+	const environment = developmentOperationEnvironment(state, '/workspace/packages/api', 'live', { PATH: '/usr/bin' }, { TREESEED_API_BASE_URL: 'https://api.treeseed.localhost' });
+	assert.equal(environment.TREESEED_DEVELOPMENT_WORKSPACE_ROOT, '/workspace');
+	assert.equal(environment.TREESEED_DEVELOPMENT_WORKTREE, '/workspace/packages/api');
+	assert.equal(environment.TREESEED_DEVELOPMENT_SESSION_ID, 'session-1');
+	assert.equal(environment.TREESEED_API_BASE_URL, 'https://api.treeseed.localhost');
+	const link = '/workspace/packages/api/node_modules/@treeseed/sdk';
+	const overlay = '/workspace/packages/sdk/.treeseed/cache/development-sessions/session-1/package';
+	const target = relativeOverlayTarget(link, overlay);
+	assert.equal(target.startsWith('/'), false);
+	assert.equal(resolve(resolve(link, '..'), target), resolve(overlay, 'current'));
 });


### PR DESCRIPTION
## Outcome

Containerized development targets can consume live package overlays from the same federated workspace and leave no declared runtime residue when a target or session stops.

## Work authority

- Work item / Issue: Closes #58
- Proposal / decision: docs/dev-release.md portable development runtime and cleanup architecture
- Assignment / checkpoint: Platform session dev-aeef9dc6-5a2
- Actor: codex-root
- Human authority: adrianwebb
- Agent / capacity provider: Codex local development agent
- Exact base ref: staging at 8c58b30a187275a410cc9e6e5ad612865e6e332c
- Exact head ref: codex/development-runtime-cleanup at b4ad7ded197c334cf4405c81e85e18774a99fcd4

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

Replace absolute overlay links with relative links, expose explicit session workspace/worktree identity to project-owned operations, execute declared setup/cleanup around bounded process lifecycle, test the command boundary, and prove the packed CLI artifact. All repository work is complete; Platform installation and live API proof follow release.

## Changes and commits

- b4ad7ded197c334cf4405c81e85e18774a99fcd4 implements relative overlays, portable operation environment, setup execution, cleanup execution, and focused tests.

## Verification

- Clean `npm ci --ignore-scripts` completed.
- `npm run verify:direct` passed.
- 41 command-boundary and runtime tests passed.
- Packed-install CLI executable smoke passed and emitted the immutable npm artifact manifest.

## Risk and rollback

Setup and cleanup remain unprivileged, project-declared command/argument arrays with existing timeouts. Cleanup runs only for an activated target. Revert b4ad7de to restore the previous behavior; stopping a session with the prior released CLI remains the fallback, followed by the project-declared cleanup command if residue exists.

## Completion summary

The generic CLI boundary is implemented and packed-artifact verified. Remaining work is an RC release, Platform/Deployment selection, and the same real API/Admin live-session retry. No production or stable selection changes in this PR.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.

