### PR TITLE
Open device approval in the default browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.26",
+  "version": "0.13.0-rc.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.26",
+      "version": "0.13.0-rc.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.40",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.26",
+  "version": "0.13.0-rc.27",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -39,7 +39,12 @@ export async function runAuth(invocation: ParsedInvocation, context: CommandCont
 	if (invocation.command.name === 'auth login') {
 		const configuredTimeout = configuredLoginTimeoutSeconds(invocation, context);
 		const authorization = await client.authorizeDevice(CONTROL_PLANE_CLI_CLIENT_ID, DEFAULT_SCOPES, AbortSignal.timeout(configuredTimeout * 1_000));
-		context.write(`Open ${authorization.verificationUriComplete ?? authorization.verificationUri} and enter code ${authorization.userCode}.`, 'stderr');
+		const verificationUrl = authorization.verificationUriComplete ?? authorization.verificationUri;
+		const opened = await Promise.resolve(context.openExternal?.(verificationUrl)).catch(() => false) ?? false;
+		if (opened) context.write('Opened your default browser. Follow the instructions there.', 'stderr');
+		else context.write('A browser could not be opened automatically.', 'stderr');
+		const codeFallback = authorization.verificationUriComplete ? '' : ` and enter code ${authorization.userCode}`;
+		context.write(`To authorize from this or another computer, open ${verificationUrl}${codeFallback}.`, 'stderr');
 		const timeoutSeconds = Math.min(configuredTimeout, authorization.expiresIn);
 		const deadline = Date.now() + timeoutSeconds * 1_000;
 		let interval = Math.max(1, authorization.interval) * 1_000;

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -14,6 +14,7 @@ import type { CommandContext, CommandFailure, ParsedInvocation, Writer } from '.
 import { promptText } from './support/prompts.js';
 import { handoffProviderEnrollment } from './support/provider-enrollment.js';
 import { renderHumanCommandResult } from './support/human-renderer.js';
+import { openBrowser } from './support/open-browser.js';
 
 function defaultWrite(output: string, stream: 'stdout' | 'stderr' = 'stdout') {
 	(stream === 'stderr' ? process.stderr : process.stdout).write(`${output}\n`);
@@ -21,7 +22,7 @@ function defaultWrite(output: string, stream: 'stdout' | 'stderr' = 'stdout') {
 
 export function createCommandContext(overrides: Partial<CommandContext> = {}): CommandContext {
 	const env = overrides.env ?? process.env;
-	const context: CommandContext = { cwd: overrides.cwd ?? process.cwd(), env, write: overrides.write ?? defaultWrite as Writer, outputFormat: overrides.outputFormat ?? 'human', interactiveUi: overrides.interactiveUi ?? true, prompt: overrides.prompt, promptSecret: overrides.promptSecret, confirm: overrides.confirm, operationInvoke: overrides.operationInvoke, hostInvoke: overrides.hostInvoke,
+	const context: CommandContext = { cwd: overrides.cwd ?? process.cwd(), env, write: overrides.write ?? defaultWrite as Writer, outputFormat: overrides.outputFormat ?? 'human', interactiveUi: overrides.interactiveUi ?? true, prompt: overrides.prompt, promptSecret: overrides.promptSecret, confirm: overrides.confirm, openExternal: overrides.openExternal ?? openBrowser, operationInvoke: overrides.operationInvoke, hostInvoke: overrides.hostInvoke,
 		providerEnrollmentHandoff: overrides.providerEnrollmentHandoff ?? ((input) => handoffProviderEnrollment(input, env)) };
 	if (!context.confirm && context.interactiveUi) context.confirm = async (question) => /^y(?:es)?$/iu.test(await promptText(context, `${question} [y/N] `));
 	return context;

--- a/src/cli/support/open-browser.ts
+++ b/src/cli/support/open-browser.ts
@@ -1,0 +1,28 @@
+import { spawn } from 'node:child_process';
+
+export interface BrowserLaunchCommand {
+	command: string;
+	arguments: string[];
+}
+
+export function browserLaunchCommand(url: string, platform = process.platform): BrowserLaunchCommand | null {
+	const target = new URL(url);
+	if (!['http:', 'https:'].includes(target.protocol)) return null;
+	if (platform === 'darwin') return { command: 'open', arguments: [target.toString()] };
+	if (platform === 'win32') return { command: 'rundll32.exe', arguments: ['url.dll,FileProtocolHandler', target.toString()] };
+	if (platform === 'linux') return { command: 'xdg-open', arguments: [target.toString()] };
+	return null;
+}
+
+export async function openBrowser(url: string) {
+	const launch = browserLaunchCommand(url);
+	if (!launch) return false;
+	return new Promise<boolean>((resolve) => {
+		const child = spawn(launch.command, launch.arguments, { detached: true, stdio: 'ignore', windowsHide: true });
+		child.once('error', () => resolve(false));
+		child.once('spawn', () => {
+			child.unref();
+			resolve(true);
+		});
+	});
+}

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -12,6 +12,7 @@ export interface CommandContext {
 	prompt?: (question: string) => Promise<string> | string;
 	promptSecret?: (question: string) => Promise<string> | string;
 	confirm?: (question: string, defaultValue?: 'yes' | 'no') => Promise<boolean> | boolean;
+	openExternal?: (url: string) => Promise<boolean> | boolean;
 	operationInvoke?: (operationId: string, input: unknown) => Promise<unknown>;
 	hostInvoke?: (input: { handlerId: string; arguments: string[]; options: Record<string, string | string[] | boolean | undefined> }) => Promise<unknown>;
 	providerEnrollmentHandoff?: (input: Record<string, unknown>) => Promise<Record<string, unknown>>;

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -408,14 +408,18 @@ test('JSON device login keeps human approval instructions off stdout', async () 
 	baseUrl = `http://127.0.0.1:${address.port}`;
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-device-'));
 	const output: Array<{ value: string; stream?: string }> = [];
+	const opened: string[] = [];
 	try {
 		saveServerProfile({ serverId: 'test', label: 'Test', baseUrl }, { TREESEED_CONFIG_HOME: root });
 		const exit = await runCommandLine(['auth', 'login', '--server', 'test', '--json'], {
 			env: { TREESEED_CONFIG_HOME: root }, interactiveUi: false,
 			write: (value, stream) => output.push({ value, stream }),
+			openExternal: async (url) => { opened.push(url); return true; },
 		});
 		assert.equal(exit, 0, JSON.stringify(output));
-		assert.match(output.find(({ stream }) => stream === 'stderr')!.value, /ABCD-EFGH/u);
+		assert.deepEqual(opened, [`${baseUrl}/approve?user_code=ABCD-EFGH`]);
+		assert.match(output.filter(({ stream }) => stream === 'stderr').map(({ value }) => value).join('\n'), /Opened your default browser/u);
+		assert.match(output.filter(({ stream }) => stream === 'stderr').map(({ value }) => value).join('\n'), /another computer.*ABCD-EFGH/u);
 		const stdout = output.filter(({ stream }) => stream === 'stdout');
 		assert.equal(stdout.length, 1);
 		assert.equal(JSON.parse(stdout[0]!.value).ok, true);

--- a/tests/unit/support/open-browser.test.ts
+++ b/tests/unit/support/open-browser.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { browserLaunchCommand } from '../../../src/cli/support/open-browser.js';
+
+const url = 'https://admin.treeseed.localhost/auth/device/approve?user_code=ABCD-EFGH';
+
+test('browser launch commands pass the complete verification URL without shell interpolation', () => {
+	assert.deepEqual(browserLaunchCommand(url, 'linux'), { command: 'xdg-open', arguments: [url] });
+	assert.deepEqual(browserLaunchCommand(url, 'darwin'), { command: 'open', arguments: [url] });
+	assert.deepEqual(browserLaunchCommand(url, 'win32'), { command: 'rundll32.exe', arguments: ['url.dll,FileProtocolHandler', url] });
+});
+
+test('browser launch commands fail closed for unsupported platforms and schemes', () => {
+	assert.equal(browserLaunchCommand(url, 'aix'), null);
+	assert.equal(browserLaunchCommand('file:///tmp/secret', 'linux'), null);
+});


### PR DESCRIPTION
Closes #64.

## Changes
- opens the complete device verification URL with the platform default-browser command
- never interpolates the URL through a shell
- always prints a copyable URL for headless and remote authorization
- keeps human guidance on stderr so JSON stdout remains stable
- covers Linux, macOS, Windows, opener success, and packed CLI behavior

## Verification
- `npm run release:verify` (44/44 tests)
- `npm run release:check-tag -- 0.13.0-rc.27`