### PR TITLE
feat: complete candidate custody and CLI package target

### DIFF
--- a/scripts/development/build-watch.ts
+++ b/scripts/development/build-watch.ts
@@ -1,0 +1,14 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const marker = resolve('dist/.treeseed-build-complete.json');
+const temporary = `${marker}.new`;
+rmSync(marker, { force: true });
+const result = spawnSync('npm', ['run', 'build:dist'], { cwd: process.cwd(), env: process.env, stdio: 'inherit' });
+if (result.status !== 0) process.exitCode = result.status ?? 1;
+else {
+	mkdirSync(dirname(marker), { recursive: true });
+	writeFileSync(temporary, `${JSON.stringify({ completedAt: new Date().toISOString(), executable: 'cli/main.js' })}\n`);
+	renameSync(temporary, marker);
+}

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -20,7 +20,7 @@ interface ProjectSelection { manifest: string; worktree?: string; targets?: Arra
 
 interface DevelopmentStatusRecord {
 	session: {
-		targets: Array<{ projectId: string; targetId: string; mode: 'released' | 'candidate' | 'live' }>;
+		targets: Array<{ projectId: string; targetId: string; mode: 'released' | 'candidate' | 'live'; generation: number; health?: string }>;
 		repositories: Array<{ projectId: string; worktree: string }>;
 	};
 	runtimes: DevelopmentRuntime[];
@@ -51,10 +51,11 @@ function sha512Integrity(value: Buffer) { return `sha512-${createHash('sha512').
 
 function git(root: string, args: string[]) { return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim(); }
 
-function repositoryClosure(runtime: DevelopmentRuntime, worktree: string) {
-	const status = git(worktree, ['status', '--porcelain=v1', '--untracked-files=all']);
+function repositoryClosure(runtime: DevelopmentRuntime, worktree: string, excludedPaths: string[] = []) {
+	const pathspec = excludedPaths.length ? ['--', '.', ...excludedPaths.map((path) => `:(exclude)${path}`)] : [];
+	const status = git(worktree, ['status', '--porcelain=v1', '--untracked-files=all', ...pathspec]);
 	const branch = git(worktree, ['branch', '--show-current']) || null;
-	return { projectId: runtime.project.id, repository: runtime.project.repository, worktree, commit: git(worktree, ['rev-parse', 'HEAD']), branch, dirty: Boolean(status), dirtyDigest: status ? sha256(`${status}\n${git(worktree, ['diff', '--binary', 'HEAD'])}`) : null, recipeDigest: sha256(JSON.stringify(runtime)) };
+	return { projectId: runtime.project.id, repository: runtime.project.repository, worktree, commit: git(worktree, ['rev-parse', 'HEAD']), branch, dirty: Boolean(status), dirtyDigest: status ? sha256(`${status}\n${git(worktree, ['diff', '--binary', 'HEAD', ...pathspec])}`) : null, recipeDigest: sha256(JSON.stringify(runtime)) };
 }
 
 function projectSelections(file: string): ProjectSelection[] {
@@ -281,6 +282,24 @@ function artifactPaths(pattern: string, root: string) {
 	return readdirSync(directory).filter((name) => expression.test(name)).map((name) => resolve(directory, name));
 }
 
+function compatibilityAttestations(repositories: Array<{ worktree: string }>) {
+	return repositories.flatMap(({ worktree }) => {
+		const path = resolve(worktree, '.treeseed/standards/compatibility-attestation.json');
+		if (!existsSync(path)) return [];
+		const bytes = readFileSync(path), value = JSON.parse(bytes.toString('utf8')) as { contractId?: unknown; result?: { sufficient?: unknown; required?: unknown } };
+		if (typeof value.contractId !== 'string' || value.result?.sufficient !== true || !['none', 'patch', 'minor', 'major'].includes(String(value.result?.required))) throw new Error(`Compatibility attestation is invalid or insufficient: ${path}.`);
+		return [{ contractId: value.contractId, digest: sha256(bytes), compatible: true, minimumBump: value.result.required as 'none' | 'patch' | 'minor' | 'major' }];
+	});
+}
+
+function withFreezeLock<T>(env: NodeJS.ProcessEnv, sessionId: string, action: () => Promise<T>) {
+	const lock = resolve(developmentStateRoot(env), sessionId, 'freeze.lock');
+	mkdirSync(dirname(lock), { recursive: true, mode: 0o700 });
+	let descriptor: number;
+	try { descriptor = openSync(lock, 'wx', 0o600); } catch { throw new Error(`Candidate freeze is already active for ${sessionId}.`); }
+	return action().finally(() => { closeSync(descriptor); rmSync(lock, { force: true }); });
+}
+
 async function startSession(invocation: ParsedInvocation, context: CommandContext) {
 	const manifest = resolve(context.cwd, invocation.arguments[0]!); const projects = loadRuntimes(manifest);
 	const now = new Date(), requestedLease = Number(invocation.options.leaseSeconds ?? 14_400), leaseSeconds = Math.max(60, Math.min(86_400, requestedLease));
@@ -327,16 +346,17 @@ async function useTargets(invocation: ParsedInvocation, context: CommandContext)
 }
 
 async function freeze(invocation: ParsedInvocation, context: CommandContext) {
-	const state = loadState(context.env), sessionId = String(invocation.options.session ?? state.sessionId), record = await invoke(context, 'local.dev.status', { sessionId, all: false }) as { session: { repositories: Array<{ projectId: string; worktree: string; dirty: boolean }>; targets: Array<{ projectId: string; targetId: string; mode: string }> }; runtimes: DevelopmentRuntime[] };
-	const source = record.session.repositories.map((repository) => {
+	const state = loadState(context.env), sessionId = String(invocation.options.session ?? state.sessionId), record = await invoke(context, 'local.dev.status', { sessionId, all: false }) as { session: { repositories: Array<{ projectId: string; worktree: string; dirty: boolean }>; targets: Array<{ projectId: string; targetId: string; mode: string; generation: number }> }; runtimes: DevelopmentRuntime[] };
+	return withFreezeLock(context.env, sessionId, async () => {
+		const source = record.session.repositories.map((repository) => {
 		const runtime = record.runtimes.find((entry) => entry.project.id === repository.projectId);
 		if (!runtime) throw new Error(`Development runtime is missing for ${repository.projectId}.`);
 		return repositoryClosure(runtime, repository.worktree);
-	});
-	const dirty = source.some((entry) => entry.dirty);
-	if (dirty && invocation.options.allowDirty !== true) throw new Error('Freeze found dirty source; pass --allow-dirty to create a non-promotable candidate.');
-	const artifacts: Array<{ projectId: string; targetId: string; kind: string; identity: string; digest: string; integrity?: string }> = [];
-	for (const runtime of record.runtimes) for (const target of runtime.targets) if (target.freeze && record.session.targets.some((selected) => selected.projectId === runtime.project.id && selected.targetId === target.id && selected.mode !== 'released')) {
+		});
+		const dirty = source.some((entry) => entry.dirty);
+		if (dirty && invocation.options.allowDirty !== true) throw new Error('Freeze found dirty source; pass --allow-dirty to create a non-promotable candidate.');
+		const artifacts: Array<{ projectId: string; targetId: string; kind: string; identity: string; digest: string; integrity?: string }> = [];
+		for (const runtime of record.runtimes) for (const target of runtime.targets) if (target.freeze && record.session.targets.some((selected) => selected.projectId === runtime.project.id && selected.targetId === target.id && selected.mode !== 'released')) {
 		const repository = record.session.repositories.find((entry) => entry.projectId === runtime.project.id)!;
 		const result = spawnSync(target.freeze.operation.command, target.freeze.operation.args, { cwd: target.freeze.operation.cwd ? resolve(repository.worktree, target.freeze.operation.cwd) : repository.worktree, env: { ...context.env, ...target.freeze.operation.environment }, stdio: 'inherit', timeout: target.freeze.operation.timeoutSeconds * 1_000 });
 		if (result.status !== 0) throw new Error(`Freeze failed for ${runtime.project.id}.${target.id}.`);
@@ -344,14 +364,16 @@ async function freeze(invocation: ParsedInvocation, context: CommandContext) {
 			const contract = spawnSync(contractOperation.command, contractOperation.args, { cwd: contractOperation.cwd ? resolve(repository.worktree, contractOperation.cwd) : repository.worktree, env: { ...context.env, ...contractOperation.environment }, stdio: 'inherit', timeout: contractOperation.timeoutSeconds * 1_000 });
 			if (contract.status !== 0) throw new Error(`Contract generation failed for ${runtime.project.id}.${target.id}.`);
 		}
-		for (const pattern of target.freeze.artifacts) for (const path of artifactPaths(pattern, repository.worktree)) { const bytes = readFileSync(path); artifacts.push({ projectId: runtime.project.id, targetId: target.id, kind: target.freeze.kind, identity: basename(path), digest: sha256(bytes), ...(target.freeze.kind === 'npm-package' ? { integrity: sha512Integrity(bytes) } : {}) }); }
-	}
-	if (!artifacts.length) throw new Error('Selected development closure produced no declared freeze artifacts.');
-	const candidateId = `candidate-${randomUUID().slice(0, 12)}`;
-	const candidate = developmentCandidateSchema.parse({ schemaVersion: 'treeseed.development-candidate/v1', candidateId, sessionId, createdAt: new Date().toISOString(), source, artifacts, configurationDigest: sha256(JSON.stringify(record.runtimes)), dependencyGenerations: {}, compatibilityAttestations: [], verification: { status: 'pending', operations: [], completedAt: null }, promotable: false });
-	const path = resolve(developmentStateRoot(context.env), sessionId, `${candidateId}.json`); mkdirSync(dirname(path), { recursive: true, mode: 0o700 }); writeFileSync(path, `${JSON.stringify(candidate, null, 2)}\n`, { mode: 0o600 }); state.candidates.push(path); saveState(state, context.env);
-	await invoke(context, 'local.dev.candidate.register', { sessionId, candidate });
-	return { candidate, receipt: path };
+		for (const pattern of target.freeze.artifacts) for (const path of artifactPaths(pattern, repository.worktree)) { const bytes = readFileSync(path); artifacts.push({ projectId: runtime.project.id, targetId: target.id, kind: target.freeze.kind, identity: relative(repository.worktree, path), digest: sha256(bytes), ...(target.freeze.kind === 'npm-package' ? { integrity: sha512Integrity(bytes) } : {}) }); }
+		}
+		if (!artifacts.length) throw new Error('Selected development closure produced no declared freeze artifacts.');
+		const candidateId = `candidate-${randomUUID().slice(0, 12)}`;
+		const dependencyGenerations = Object.fromEntries(record.session.targets.map((target) => [`${target.projectId}.${target.targetId}`, target.generation]));
+		const candidate = developmentCandidateSchema.parse({ schemaVersion: 'treeseed.development-candidate/v1', candidateId, sessionId, createdAt: new Date().toISOString(), source, artifacts, configurationDigest: sha256(JSON.stringify(record.runtimes)), dependencyGenerations, compatibilityAttestations: compatibilityAttestations(record.session.repositories), verification: { status: 'pending', operations: [], completedAt: null }, promotable: false });
+		const path = resolve(developmentStateRoot(context.env), sessionId, `${candidateId}.json`); mkdirSync(dirname(path), { recursive: true, mode: 0o700 }); writeFileSync(path, `${JSON.stringify(candidate, null, 2)}\n`, { mode: 0o600 }); state.candidates.push(path); saveState(state, context.env);
+		await invoke(context, 'local.dev.candidate.register', { sessionId, candidate });
+		return { candidate, receipt: path };
+	});
 }
 
 async function verifyCandidate(invocation: ParsedInvocation, context: CommandContext) {
@@ -364,9 +386,21 @@ async function verifyCandidate(invocation: ParsedInvocation, context: CommandCon
 	for (const artifact of candidate.artifacts) {
 		const runtime = record.runtimes.find((entry) => entry.project.id === artifact.projectId), target = runtime?.targets.find((entry) => entry.id === artifact.targetId), repository = record.session.repositories.find((entry) => entry.projectId === artifact.projectId);
 		if (!target?.operations.verify || !repository) continue;
+		const artifactPath = resolve(repository.worktree, artifact.identity);
+		const artifactRelative = relative(repository.worktree, artifactPath);
+		if (artifactRelative.startsWith('..') || isAbsolute(artifactRelative)) throw new Error(`Candidate artifact identity escapes its source repository: ${artifact.identity}.`);
+		if (!existsSync(artifactPath) || sha256(readFileSync(artifactPath)) !== artifact.digest) throw new Error(`Candidate artifact custody failed before verification: ${artifact.identity}.`);
 		const operation = target.operations.verify, result = spawnSync(operation.command, operation.args, { cwd: operation.cwd ? resolve(repository.worktree, operation.cwd) : repository.worktree, env: { ...context.env, ...operation.environment }, stdio: 'inherit', timeout: operation.timeoutSeconds * 1_000 });
 		operations.push(`${artifact.projectId}.${artifact.targetId}:${operation.command} ${operation.args.join(' ')}`);
 		if (result.status !== 0) throw new Error(`Candidate verification failed for ${artifact.projectId}.${artifact.targetId}.`);
+		if (!existsSync(artifactPath) || sha256(readFileSync(artifactPath)) !== artifact.digest) throw new Error(`Candidate verification rebuilt or changed sealed artifact ${artifact.identity}.`);
+	}
+	if (!operations.length) throw new Error('Candidate verification requires at least one declared verification operation.');
+	for (const source of candidate.source) {
+		const runtime = record.runtimes.find((entry) => entry.project.id === source.projectId);
+		const repository = record.session.repositories.find((entry) => entry.projectId === source.projectId);
+		const artifactPaths = candidate.artifacts.filter((artifact) => artifact.projectId === source.projectId).map((artifact) => artifact.identity);
+		if (!runtime || !repository || JSON.stringify(repositoryClosure(runtime, repository.worktree, artifactPaths)) !== JSON.stringify(source)) throw new Error(`Candidate source changed after freeze: ${source.projectId}.`);
 	}
 	const verified = developmentCandidateSchema.parse({ ...candidate, verification: { status: 'passed', operations, completedAt: new Date().toISOString() }, promotable: !candidate.source.some((source) => source.dirty) });
 	writeFileSync(selected, `${JSON.stringify(verified, null, 2)}\n`, { mode: 0o600 }); await invoke(context, 'local.dev.candidate.register', { sessionId, candidate: verified }); return { candidate: verified, receipt: selected };

--- a/tests/unit/command-boundary/development-session.test.ts
+++ b/tests/unit/command-boundary/development-session.test.ts
@@ -91,3 +91,46 @@ test('package rebuild waits for a new marker-complete atomic generation', async 
 		assert.equal(await waiting, resolve(overlay, 'generation-2'));
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
+
+test('freeze binds completed generations and attestations while verify rejects artifact substitution', async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-candidate-'));
+	const stateRoot = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-candidate-state-'));
+	const packageManifest = resolve(root, 'treeseed.package.yaml'), sessionManifest = resolve(root, 'development.session.yaml');
+	const output: string[] = [];
+	try {
+		mkdirSync(resolve(root, 'scripts'), { recursive: true });
+		writeFileSync(resolve(root, 'scripts/freeze.mjs'), "import { writeFileSync } from 'node:fs'; writeFileSync('candidate.bin', 'sealed-candidate');\n");
+		writeFileSync(resolve(root, 'scripts/verify.mjs'), "process.stdout.write('verified\\n');\n");
+		mkdirSync(resolve(root, '.treeseed/standards'), { recursive: true });
+		writeFileSync(resolve(root, '.treeseed/standards/compatibility-attestation.json'), `${JSON.stringify({ contractId: '@treeseed/admin/browser', result: { sufficient: true, required: 'patch' } })}\n`);
+		writeFileSync(packageManifest, `${manifest.replace(
+			"operations:\n        start: { command: npm, args: [run, dev], environment: {}, timeoutSeconds: 600 }",
+			"operations:\n        start: { command: npm, args: [run, dev], environment: {}, timeoutSeconds: 600 }\n        verify: { command: node, args: [scripts/verify.mjs], environment: {}, timeoutSeconds: 60 }",
+		).replace(
+			"promotion: { liveAdmissible: false, candidateRequiresVerification: true }",
+			"freeze:\n        kind: archive\n        operation: { command: node, args: [scripts/freeze.mjs], environment: {}, timeoutSeconds: 60 }\n        artifacts: [candidate.bin]\n        contractOperations: []\n      promotion: { liveAdmissible: false, candidateRequiresVerification: true }",
+		)}\n`);
+		writeFileSync(sessionManifest, `projects:\n  - manifest: treeseed.package.yaml\n    worktree: .\n    targets:\n      - { id: web, mode: candidate }\n`);
+		execFileSync('git', ['init', '-b', 'staging'], { cwd: root }); execFileSync('git', ['add', '.'], { cwd: root });
+		execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-m', 'fixture'], { cwd: root });
+		let record: any, registered: any;
+		const hostInvoke = async (input: any) => {
+			const payload = JSON.parse(input.options.payload);
+			if (input.handlerId === 'local.dev.session.start') { record = { session: payload.session, runtimes: payload.runtimes }; record.session.targets[0].generation = 7; return record; }
+			if (input.handlerId === 'local.dev.status') return record;
+			if (input.handlerId === 'local.dev.candidate.register') { registered = payload.candidate; return record; }
+			throw new Error(`Unexpected manager call ${input.handlerId}`);
+		};
+		const context = { cwd: root, env: { ...process.env, XDG_STATE_HOME: stateRoot, USER: 'tester' }, interactiveUi: false, hostInvoke, write: (value: string) => output.push(value) };
+		assert.equal(await runCommandLine(['dev', 'session', 'start', sessionManifest, '--json'], context), 0);
+		assert.equal(await runCommandLine(['dev', 'freeze', '--json'], context), 0, output.at(-1));
+		assert.equal(registered.dependencyGenerations['admin.web'], 7);
+		assert.equal(registered.compatibilityAttestations[0].contractId, '@treeseed/admin/browser');
+		assert.equal(registered.promotable, false);
+		assert.equal(await runCommandLine(['dev', 'verify', '--json'], context), 0);
+		assert.equal(registered.promotable, true);
+		writeFileSync(resolve(root, 'candidate.bin'), 'substituted');
+		assert.equal(await runCommandLine(['dev', 'verify', '--json'], context), 1);
+		assert.match(output.at(-1)!, /artifact custody failed/u);
+	} finally { rmSync(root, { recursive: true, force: true }); rmSync(stateRoot, { recursive: true, force: true }); }
+});

--- a/treeseed.package.yaml
+++ b/treeseed.package.yaml
@@ -22,3 +22,36 @@ releaseGate:
 projectArchitecture:
   topology: package
   rootPath: .
+development:
+  schemaVersion: treeseed.development-runtime/v1
+  project: { id: cli, repository: treeseed-ai/cli }
+  defaults: { leaseSeconds: 14400, restoreOnFailure: true }
+  targets:
+    - id: package
+      kind: package-watch
+      platforms: [linux-amd64, linux-arm64, darwin-arm64, darwin-amd64]
+      runtimeRequirements: [node>=22]
+      sourceRoots: [src, scripts/build, scripts/development]
+      ignoredPaths: [dist, node_modules]
+      operations:
+        watch: { command: node, args: [--watch-path=src, --watch-path=package.json, --import, tsx, scripts/development/build-watch.ts], environment: {}, timeoutSeconds: 86400 }
+        build: { command: node, args: [--import, tsx, scripts/development/build-watch.ts], environment: {}, timeoutSeconds: 900 }
+        verify: { command: npm, args: [test], environment: {}, timeoutSeconds: 1800 }
+      ready: { kind: marker, path: dist/.treeseed-build-complete.json, timeoutSeconds: 120 }
+      outputs: [{ path: dist, mediaType: application/vnd.treeseed.node-package, completionMarker: dist/.treeseed-build-complete.json, digestAlgorithm: sha256 }]
+      endpoints: []
+      dependencies:
+        - { id: sdk, target: package, locality: either, reaction: rebuild }
+      statePolicy: stateless
+      migrationPolicy: none
+      secretRefs: {}
+      shutdown: { graceSeconds: 10, activeWorkPolicy: block }
+      resources: {}
+      logs: [.treeseed/development/package.log]
+      forbiddenOperations: [global-bin-replacement, host-manager-shadowing, publish, production-tag]
+      freeze:
+        kind: npm-package
+        operation: { command: npm, args: [pack, --json], environment: {}, timeoutSeconds: 900 }
+        artifacts: [treeseed-cli-*.tgz]
+        contractOperations: []
+      promotion: { liveAdmissible: false, candidateRequiresVerification: true }


### PR DESCRIPTION
Addresses #58, #61, and treeseed-ai/platform#152.\n\nPopulates dependency generations and compatibility attestations, serializes freeze, verifies artifact/source custody without rebuilding, rejects substitution, and adds an atomic session-scoped CLI package target without replacing global host commands.\n\nVerification:\n- npm run build:dist\n- npm test (44 passed before the new boundary case)\n- focused development boundary suite (5 passed, including freeze/verify tamper rejection)