### PR TITLE
ci: promote sealed CLI candidate artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,78 +1,44 @@
-name: Publish TreeSeed CLI
+name: Promote TreeSeed CLI Candidate
 
 on:
   push:
-    tags:
-      - "*.*.*"
-  workflow_dispatch:
+    tags: ["*.*.*"]
 
 jobs:
-  npm:
-    if: startsWith(github.ref, 'refs/tags/')
+  promote:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      id-token: write
+    permissions: { actions: read, contents: write, id-token: write }
     environment: production
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with: { fetch-depth: 0 }
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-      - run: npm run release:setup
-      - run: npm run release:check-tag
-      - run: bash -lc 'npm run verify:local'
-      - name: Pack the exact verified package
-        id: pack
-        shell: bash
+        with: { node-version: 24, registry-url: https://registry.npmjs.org }
+      - name: Download exact protected staging candidate
+        env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
         run: |
-          set -euo pipefail
-          mkdir -p artifacts
-          npm pack --json --ignore-scripts --pack-destination artifacts > artifacts/pack.json
-          filename="$(node -e "const value=require('./artifacts/pack.json'); process.stdout.write(value[0].filename)")"
-          sha256="$(sha256sum "artifacts/${filename}" | awk '{print $1}')"
-          echo "filename=${filename}" >> "$GITHUB_OUTPUT"
-          echo "sha256=${sha256}" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: cli-release-${{ github.sha }}
-          path: artifacts/
-          if-no-files-found: error
+          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/staging)"
+          run_id="$(gh run list --workflow verify.yml --branch staging --commit "$GITHUB_SHA" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
+          test -n "$run_id"
+          gh run download "$run_id" --name "cli-candidate-${GITHUB_SHA}" --dir candidate
+      - run: npm ci --ignore-scripts --no-audit --no-fund
+      - run: npm run release:check-tag
+      - run: npm run release:custody -- verify candidate/release-evidence-v1.json
       - name: Capture stable tag before publication
         id: before
         run: echo "latest=$(npm view @treeseed/cli dist-tags.latest)" >> "$GITHUB_OUTPUT"
-      - run: npm run release:publish -- "artifacts/${{ steps.pack.outputs.filename }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish accepted tarball directly
+        run: npm run release:publish -- "$(find candidate -maxdepth 1 -name '*.tgz' -print -quit)"
+        env: { NODE_AUTH_TOKEN: "${{ secrets.NPM_TOKEN }}" }
       - name: Verify immutable npm read-back
         env:
           EXPECTED_LATEST: ${{ steps.before.outputs.latest }}
-          EXPECTED_SHA256: ${{ steps.pack.outputs.sha256 }}
-        run: node --import tsx ./scripts/packages/verify-published-package.ts
-
-  release:
-    needs: npm
-    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-rc.')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag
-
-  prerelease:
-    needs: npm
-    if: startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-rc.')
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-      - name: Create GitHub prerelease
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag --prerelease
+        run: |
+          export EXPECTED_SHA256="$(node -e "const e=require('./candidate/release-evidence-v1.json'); process.stdout.write(e.artifacts.find(x=>x.kind==='npm-package').digest.slice(7))")"
+          node --import tsx ./scripts/packages/verify-published-package.ts
+      - name: Publish unchanged custody assets
+        env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
+        run: |
+          flags=()
+          if [[ "$GITHUB_REF_NAME" == *-rc.* ]]; then flags+=(--prerelease); fi
+          gh release create "$GITHUB_REF_NAME" candidate/*.tgz candidate/sbom.cdx.json candidate/release-evidence-v1.json --generate-notes --verify-tag "${flags[@]}"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -33,8 +33,25 @@ jobs:
       - name: Verify package
         run: npm run verify:direct
 
+      - name: Seal protected staging candidate
+        if: github.ref == 'refs/heads/staging'
+        run: |
+          npm sbom --sbom-format cyclonedx > artifacts/sbom.cdx.json
+          artifact="$(find artifacts -maxdepth 1 -name '*.tgz' -print -quit)"
+          npm run release:custody -- seal artifacts/release-evidence-v1.json "$artifact"
+          npm run release:custody -- verify artifacts/release-evidence-v1.json
+
       - uses: actions/upload-artifact@v4
         with:
           name: cli-${{ github.sha }}
           path: artifacts/*.tgz
           if-no-files-found: error
+
+      - name: Upload sealed staging custody
+        if: github.ref == 'refs/heads/staging'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-candidate-${{ github.sha }}
+          path: artifacts/
+          if-no-files-found: error
+          retention-days: 30

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.13.0-rc.27",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.40",
+        "@treeseed/sdk": "0.13.0-rc.47",
         "yaml": "2.8.1"
       },
       "bin": {
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.40",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.40.tgz",
-      "integrity": "sha512-GHfsrU/FWe2/hBF2KBMqTnXkyAN4CRn+PE0/Ixlpro6ZnPxAwJ9G9tLjK8wlf70BAXHJeSGXf4E+otdPoQq/YQ==",
+      "version": "0.13.0-rc.47",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.47.tgz",
+      "integrity": "sha512-Z5biEwnNJ2+kOFOxiUyeDIE/zTpCGe7zSyqkQOwO/K/HAfCtAT7kH1KRQ9DEzyHNdonhqsMViHQoxXY0TsATiA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,11 @@
     "pack:artifact": "node --import tsx ./scripts/packages/pack-package-artifact.ts",
     "release:check-tag": "node --import tsx ./scripts/packages/assert-release-tag-version.ts",
     "release:verify": "node --import tsx ./scripts/packages/release-verify.ts",
-    "release:publish": "node --import tsx ./scripts/packages/publish-package.ts"
+    "release:publish": "node --import tsx ./scripts/packages/publish-package.ts",
+    "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.40",
+    "@treeseed/sdk": "0.13.0-rc.47",
     "yaml": "2.8.1"
   },
   "overrides": {

--- a/scripts/packages/release-custody.ts
+++ b/scripts/packages/release-custody.ts
@@ -1,0 +1,40 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, statSync, writeFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { releaseEvidenceSchema } from '@treeseed/sdk/development';
+
+const root = resolve(import.meta.dirname, '../..');
+const sha256 = (path: string) => `sha256:${createHash('sha256').update(readFileSync(path)).digest('hex')}` as const;
+const command = process.argv[2], evidencePath = resolve(root, process.argv[3] ?? 'artifacts/release-evidence-v1.json');
+
+if (command === 'seal') {
+	const artifactPath = resolve(root, process.argv[4]!), sbomPath = resolve(root, 'artifacts/sbom.cdx.json');
+	const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as { name: string; version: string };
+	const sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+	const artifactDigest = sha256(artifactPath), sbomDigest = sha256(sbomPath);
+	const receiptDigest = `sha256:${createHash('sha256').update(`${sourceCommit}\n${artifactDigest}\n${sbomDigest}`).digest('hex')}` as const;
+	const evidence = releaseEvidenceSchema.parse({
+		schemaVersion: 'treeseed.release-evidence/v1',
+		candidate: { id: `candidate-${sourceCommit.slice(0, 12)}`, receiptDigest, sourceCommit, stagingRef: process.env.GITHUB_REF ?? 'refs/heads/staging', workflowRunId: process.env.GITHUB_RUN_ID ?? '1', createdAt: new Date().toISOString() },
+		packages: [{ projectId: 'cli', name: packageJson.name, version: packageJson.version, minimumBump: 'patch' }],
+		artifacts: [
+			{ id: 'cli-package', kind: 'npm-package', identity: basename(artifactPath), digest: artifactDigest, mediaType: 'application/gzip', size: statSync(artifactPath).size },
+			{ id: 'cli-sbom', kind: 'sbom', identity: basename(sbomPath), digest: sbomDigest, mediaType: 'application/vnd.cyclonedx+json', size: statSync(sbomPath).size },
+		],
+		contractBundles: [], compatibilityAttestations: [],
+		verification: { status: 'passed', operations: ['npm run verify:direct'], completedAt: new Date().toISOString() },
+	});
+	writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`);
+	console.log(JSON.stringify({ ok: true, evidencePath, artifactDigest }));
+} else if (command === 'verify') {
+	const evidence = releaseEvidenceSchema.parse(JSON.parse(readFileSync(evidencePath, 'utf8')));
+	const commit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+	if (evidence.candidate.sourceCommit !== commit) throw new Error('Candidate custody source commit differs from the tagged commit.');
+	if (process.env.GITHUB_REF?.startsWith('refs/tags/') && process.env.GITHUB_REF_NAME !== evidence.packages[0]?.version) throw new Error('Tag does not match sealed package version.');
+	for (const artifact of evidence.artifacts) {
+		const path = resolve(evidencePath, '..', artifact.identity);
+		if (sha256(path) !== artifact.digest) throw new Error(`Candidate artifact digest mismatch: ${artifact.identity}.`);
+	}
+	console.log(JSON.stringify({ ok: true, candidateId: evidence.candidate.id, artifacts: evidence.artifacts.length }));
+} else throw new Error('release-custody requires seal or verify.');

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -11,7 +11,7 @@ test('package has one executable and no runtime package dependency', () => {
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
 	assert.equal(pkg.dependencies.ink, undefined);
 	assert.equal(pkg.dependencies.react, undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.40', yaml: '2.8.1' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.47', yaml: '2.8.1' });
 });
 
 test('built package contains executable runtime only', () => {


### PR DESCRIPTION
Addresses treeseed-ai/platform#152.\n\nProtected staging verification now seals SDK-validated release evidence, tarball, and SBOM. Tag publication resolves that exact successful commit artifact, verifies custody, publishes the tarball directly, reads it back, and attaches unchanged assets. The promotion workflow contains no build or pack command. Also hydrates SDK rc.47.\n\nLocal custody seal and verification passed.