### PR TITLE
release: prepare CLI 0.13.0-rc.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.27",
+  "version": "0.13.0-rc.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.27",
+      "version": "0.13.0-rc.28",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.47",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.27",
+  "version": "0.13.0-rc.28",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Prepare the first CLI RC from SDK-owned sealed staging custody. The tag workflow publishes the accepted tarball directly, verifies registry read-back, and preserves npm latest. Tracks treeseed-ai/platform#152.