### PR TITLE
Prepare CLI 0.13.0-rc.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.28",
+  "version": "0.13.0-rc.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.28",
+      "version": "0.13.0-rc.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.48",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.28",
+  "version": "0.13.0-rc.29",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Completes #67 by assigning an unused release version after 0.13.0-rc.28 was independently published. Version-only change on top of merged SDK-derived TreeAI commands. Exact base: e90266dbadceb31c2f15091ea03a106a546814f9. Rollback: do not publish or revert.