### PR TITLE
feat(ai): route GPU mode through host manager

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1592,22 +1592,24 @@ Mode operations.
 Show the selected resource.
 
 Operation: read. Result schema: `treeseed.command.show/v1`.
-Control-plane operation: `treeai.qualification.get.mode`.
+Execution: `local.host.ai.mode.show`.
 
 - `--server <value>`: Control-plane server profile or URL.
 - `--json`: Emit the stable JSON envelope.
 
 ### trsd ai mode set <mode>
 
-Set the selected resource.
+Transition the exclusive AI GPU resource to awake or sleep.
 
-Operation: mutation. Result schema: `treeseed.command.set/v1`.
-Control-plane operation: `treeai.qualification.post.mode`.
+Operation: mutation. Result schema: `treeseed.ai-mode-transition-receipt/v1`.
+Execution: `local.host.ai.mode.set`.
 
 - `--server <value>`: Control-plane server profile or URL.
 - `--yes`: Confirm authorized automation.
 - `--json`: Emit the stable JSON envelope.
 - `--plan`: Return the exact proposed outcome without mutation.
+- `--idempotency-key <value>`: Replay-safe transition identity.
+- `--drain-timeout <value>`: Maximum drain wait in seconds.
 
 ## trsd ai inference
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.29",
+  "version": "0.13.0-rc.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.29",
+      "version": "0.13.0-rc.30",
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.48",
+        "@treeseed/sdk": "0.13.0-rc.52",
         "yaml": "2.8.1"
       },
       "bin": {
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.48",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.48.tgz",
-      "integrity": "sha512-QAkEd8/u00Nw+YC5IO4GzsjS7uW/SsJ/cnu/lar1e8vetxarnmNm+CG/ZDSsQ+r+4rYh7Ikp5DR4VBVLfvdx7g==",
+      "version": "0.13.0-rc.52",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.52.tgz",
+      "integrity": "sha512-likglVxDhv50N/4uGeKlxJFp+B6xhLeissA8lXM4bHVsQk3FHUdHTrJCcaEiHaNVXg2MMvf+aZaN12y0k2miEw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.29",
+  "version": "0.13.0-rc.30",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -50,7 +50,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.48",
+    "@treeseed/sdk": "0.13.0-rc.52",
     "yaml": "2.8.1"
   },
   "overrides": {

--- a/schemas/command-tree.json
+++ b/schemas/command-tree.json
@@ -3973,24 +3973,14 @@
               "kind": "read",
               "resultSchemaId": "treeseed.command.show/v1",
               "execution": {
-                "kind": "operation",
-                "operationId": "treeai.qualification.get.mode",
-                "input": [
-                  {
-                    "target": "path",
-                    "field": "nodeId",
-                    "source": "context",
-                    "name": "node",
-                    "required": true,
-                    "transform": "identity"
-                  }
-                ]
+                "kind": "local",
+                "handlerId": "local.host.ai.mode.show"
               }
             },
             {
               "nodeType": "leaf",
               "segment": "set",
-              "description": "Set the selected resource.",
+              "description": "Transition the exclusive AI GPU resource to awake or sleep.",
               "kind": "mutation",
               "arguments": [
                 {
@@ -4004,34 +3994,26 @@
                   "name": "--plan",
                   "description": "Return the exact proposed outcome without mutation.",
                   "type": "boolean"
+                },
+                {
+                  "name": "--idempotency-key",
+                  "description": "Replay-safe transition identity.",
+                  "type": "string"
+                },
+                {
+                  "name": "--drain-timeout",
+                  "description": "Maximum drain wait in seconds.",
+                  "type": "number"
                 }
               ],
               "authorization": {
-                "capability": "command.set",
+                "capability": "host.ai.mode",
                 "confirmation": "authority"
               },
-              "resultSchemaId": "treeseed.command.set/v1",
+              "resultSchemaId": "treeseed.ai-mode-transition-receipt/v1",
               "execution": {
-                "kind": "operation",
-                "operationId": "treeai.qualification.post.mode",
-                "input": [
-                  {
-                    "target": "path",
-                    "field": "nodeId",
-                    "source": "context",
-                    "name": "node",
-                    "required": true,
-                    "transform": "identity"
-                  },
-                  {
-                    "target": "body",
-                    "field": "mode",
-                    "source": "argument",
-                    "name": "mode",
-                    "required": true,
-                    "transform": "identity"
-                  }
-                ]
+                "kind": "local",
+                "handlerId": "local.host.ai.mode.set"
               }
             }
           ]

--- a/src/cli/registry.ts
+++ b/src/cli/registry.ts
@@ -32,7 +32,7 @@ const contextOptions: OptionSpec[] = [
 function optionNames(path: string[], leaf: CommandLeafDescriptor) {
 	const names = new Set(['json']);
 	if (leaf.execution.kind === 'operation' || leaf.execution.kind === 'protocol') names.add('server');
-	if (path[0] === 'host') names.add('server');
+	if (path[0] === 'host' || leaf.execution.kind === 'local' && leaf.execution.handlerId.startsWith('local.host.')) names.add('server');
 	if (leaf.execution.kind === 'operation') for (const binding of leaf.execution.input) if (binding.source === 'option' || binding.source === 'context') names.add(binding.name);
 	if (leaf.kind === 'mutation' && leaf.authorization?.confirmation && leaf.authorization.confirmation !== 'never') names.add('yes');
 	return names;

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -64,7 +64,7 @@ async function execute(invocation: ParsedInvocation, context: CommandContext) {
 	if (invocation.command.execution.kind === 'local' && invocation.command.path[0] === 'teams') return runTeams(invocation, context);
 	if (invocation.command.execution.kind === 'protocol') return runAuth(invocation, context);
 	if (invocation.command.execution.kind === 'local' && invocation.command.path[0] === 'secrets') return runSecrets(invocation, context);
-	if (invocation.command.execution.kind === 'local' && invocation.command.path[0] === 'host') return runHost(invocation, context);
+	if (invocation.command.execution.kind === 'local' && invocation.command.execution.handlerId.startsWith('local.host.')) return runHost(invocation, context);
 	if (invocation.command.execution.kind === 'local' && invocation.command.path[0] === 'dev') return runDevelopment(invocation, context);
 	if (invocation.command.execution.kind === 'local' && invocation.command.path[0] === 'library') return runLibrary(invocation, context);
 	return runOperator(invocation, context);

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -11,7 +11,7 @@ test('package has one executable and no runtime package dependency', () => {
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
 	assert.equal(pkg.dependencies.ink, undefined);
 	assert.equal(pkg.dependencies.react, undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.48', yaml: '2.8.1' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.52', yaml: '2.8.1' });
 });
 
 test('built package contains executable runtime only', () => {

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -59,6 +59,16 @@ test('host commands preserve the SDK handler boundary and stable envelope', asyn
 	assert.deepEqual(JSON.parse(output[0]!).result, { componentId: 'agent', healthy: true });
 });
 
+test('AI mode commands use the same bounded host-manager authority', async () => {
+	const calls: unknown[] = []; const output: string[] = [];
+	const exit = await runCommandLine(['ai', 'mode', 'set', 'sleep', '--idempotency-key', 'cycle-1', '--drain-timeout', '120', '--yes', '--json'], {
+		interactiveUi: false, hostInvoke: async (input) => { calls.push(input); return { state: 'succeeded', to: 'sleep' }; }, write: (value) => output.push(value),
+	});
+	assert.equal(exit, 0);
+	assert.deepEqual(calls, [{ handlerId: 'local.host.ai.mode.set', arguments: ['sleep'], options: { idempotencyKey: 'cycle-1', drainTimeout: '120' } }]);
+	assert.equal(JSON.parse(output[0]!).result.to, 'sleep');
+});
+
 test('host configuration adoption sends validated content and requires explicit confirmation', async () => {
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-host-config-'));
 	const file = resolve(root, 'host.json');


### PR DESCRIPTION
## Summary
- consume SDK `0.13.0-rc.52`
- route SDK-local `trsd ai mode show|set` through the existing protected host client
- expose the remote manager profile option without adding a second lifecycle authority
- prepare CLI `0.13.0-rc.30`

## Verification
- `npm run verify:direct`
- 46 tests passed
- packed-install/bin smoke passed

Closes #73
Supports treeseed-ai/deployment#215.