### PR TITLE
Summarize host security initialization

### DIFF
--- a/src/cli/support/human-renderer.ts
+++ b/src/cli/support/human-renderer.ts
@@ -106,6 +106,19 @@ export function renderHumanCommandResult(value: unknown, options: RenderOptions 
 	}
 	if (path === 'teams current' && result) { const team = result.team as Record<string, unknown>; return `Active team: ${scalar(team.name)} (${scalar(team.slug)})\nTeam ID: ${scalar(team.id)}`; }
 	if (path === 'teams use' && result && result.team) { const team = result.team as Record<string, unknown>; return `Active team set to ${scalar(team.name)} (${scalar(team.slug)}).`; }
+	if (path === 'host security initialize' && result) {
+		const receipt = result.receipt && typeof result.receipt === 'object' ? result.receipt as Record<string, unknown> : {};
+		const sandbox = receipt.sandbox && typeof receipt.sandbox === 'object' ? receipt.sandbox as Record<string, unknown> : {};
+		const providerVolume = receipt.providerVolume && typeof receipt.providerVolume === 'object' ? receipt.providerVolume as Record<string, unknown> : {};
+		const ready = sandbox.brokerReady === true && receipt.state === 'known-good';
+		return [ready ? 'Host security initialized.' : 'Host encryption initialized; sandbox readiness still needs attention.',
+			`Encrypted provider volume: ${providerVolume.encrypted === true && result.verified === true ? 'verified' : 'not verified'}`,
+			`Recovery bundle: ${result.recoveryBundleVerified === true ? 'verified' : 'not verified'}`,
+			`Kata sandbox broker: ${ready ? 'ready' : 'not ready'}`,
+			receipt.receiptId ? `Receipt: ${scalar(receipt.receiptId)}` : '',
+			ready ? '' : 'Next: run `trsd host sandbox doctor`.',
+		].filter(Boolean).join('\n');
+	}
 	if (path === 'inbox' && result?.interactiveSession === true) return '';
 	if (path === 'send' && result) return result.humanStreamed === true || result.interactiveSession === true ? '' : renderCommunicationResponses(result, options);
 	const rendered = lines(envelope.result);

--- a/tests/unit/command-boundary/human-renderer.test.ts
+++ b/tests/unit/command-boundary/human-renderer.test.ts
@@ -19,6 +19,16 @@ test('generic human output renders labels and values without JSON punctuation', 
 	assert.doesNotMatch(output, /[{}]/u);
 });
 
+test('host security initialization is summarized without dumping its receipt', () => {
+	const output = renderHumanCommandResult({ commandPath: ['host', 'security', 'initialize'], ok: true, result: {
+		verified: true, recoveryBundleVerified: true, receipt: { receiptId: 'security-test', state: 'known-good', sandbox: { brokerReady: true, guestImageDigests: ['sha256:a', 'sha256:a'] }, providerVolume: { encrypted: true } },
+	} });
+	assert.match(output, /Host security initialized\./u);
+	assert.match(output, /Kata sandbox broker: ready/u);
+	assert.match(output, /Receipt: security-test/u);
+	assert.doesNotMatch(output, /Guest Image Digests|Schema Version|sha256:a/u);
+});
+
 test('communication responses render as separated Markdown messages without redundant state', () => {
 	const output = renderHumanCommandResult({ commandPath: ['send'], ok: true, result: {
 		channel: 'engineering', status: 'complete', sendId: 'send-1',


### PR DESCRIPTION
Render host security initialization as a concise readiness summary and receipt ID instead of recursively dumping the complete receipt. JSON mode remains unchanged. Tested with the focused human-renderer suite.