### PR TITLE
Enforce canonical deployment boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ The CLI is an Apache-2.0 repository. It has no contributor-grant checkbox, appro
 
 Agents must act only within their assignment authority, preserve exact repository and commit evidence, keep password and token material out of arguments and logs, and keep GitHub credentials outside execution workspaces. Preserve fully local operation without a hosted Market dependency.
 
+## Branch and deployment boundary
+
+`main` is the only production branch and maps only to the `production` deployment environment. `staging` is the only development-integration branch and maps only to the `staging` deployment environment. Short-lived pull-request branches may validate without deploying, but they must never define another deployment environment. Do not create or use `development`, `preview`, `stable`, or any other GitHub deployment environment; preview deployments are prohibited. Release tags may promote an exact reviewed `staging` commit to `production` without creating another branch or environment. Artifact channel names must never become GitHub deployment environments.
+
 ## Project library
 
 Use `trsd library show cli` and `status` before querying `treeseed-ai/cli-library`. Read root-level paths at an exact commit. Author only through governed library workspaces and reviews. Never recreate `src/content` or edit `.treeseed/data` directly.


### PR DESCRIPTION
Enforces the portfolio rule: main maps only to production; staging maps only to staging; short-lived PR branches do not create additional deployment environments; preview deployments are prohibited. Verification: workflow syntax and policy audit.