### PR TITLE
chore: prepare CLI 0.13.0-rc.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.37",
+  "version": "0.13.0-rc.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.37",
+      "version": "0.13.0-rc.38",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.37",
+  "version": "0.13.0-rc.38",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Promote the governed R2 environment reset command and exact SDK 0.13.0-rc.60 dependency as CLI 0.13.0-rc.38.

## Verification

- `npm run verify`
- 67 tests passed

The temporary release branch will be deleted immediately after merge.