### PR TITLE
Make development rebuilds reliable and plan-safe

### DIFF
--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -328,6 +328,12 @@ async function rebuild(invocation: ParsedInvocation, context: CommandContext, st
 	const repository = record.session.repositories.find((entry) => entry.projectId === selection.projectId);
 	if (!repository) throw new Error(`No worktree is registered for ${selection.projectId}.`);
 	const mode = selected.mode as 'candidate' | 'live';
+	if (invocation.options.plan === true) return {
+		sessionId,
+		target: `${selection.projectId}.${selection.targetId}`,
+		mode,
+		mutation: false,
+	};
 	if (target.kind === 'package-watch') await rebuildPackage({ state, runtime, target, worktree: repository.worktree, mode, context });
 	else if (target.kind === 'rebuild-restart') {
 		if (!target.operations.build) throw new Error(`${selection.projectId}.${selection.targetId} does not declare a build operation.`);

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -108,6 +108,7 @@ export async function runCommandLine(argv: string[], overrides: Partial<CommandC
 		const result = api && 'payload' in api ? api.payload : response && typeof response === 'object' && 'data' in response ? (response as { data: unknown }).data : response;
 		print(context, envelope(invocation, true, result)); return 0;
 	} catch (error) {
+		if (context.env.TREESEED_DEBUG_STACK === '1' && error instanceof Error && error.stack) context.write(error.stack, 'stderr');
 		const failed = categorized(error);
 		const partial = error && typeof error === 'object' && 'partialResult' in error ? (error as { partialResult?: unknown }).partialResult : null;
 		const failedEnvelope = envelope(invocation, false, partial, failed);

--- a/src/cli/support/host-client.ts
+++ b/src/cli/support/host-client.ts
@@ -32,8 +32,10 @@ function invoke(options: Parameters<typeof requestHttp>[0], body: string, secure
 	});
 }
 
-export function invokeLocalHostManager(input: unknown) {
-	return invoke({ socketPath: managerSocket }, JSON.stringify(input), false);
+export function invokeLocalHostManager(input: unknown, socketPath = managerSocket) {
+	// Development operations may spend minutes building between manager calls.
+	// A closed idle Unix-socket connection must never be reused for the next call.
+	return invoke({ socketPath, agent: false }, JSON.stringify(input), false);
 }
 
 export function invokeHostManager(input: unknown, server: string | undefined, env: NodeJS.ProcessEnv) {

--- a/tests/unit/command-boundary/support/host-client.test.ts
+++ b/tests/unit/command-boundary/support/host-client.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { invokeLocalHostManager } from '../../../../src/cli/support/host-client.ts';
+
+test('local host manager calls use fresh Unix-socket connections after long development operations', async () => {
+	const root = mkdtempSync(join(tmpdir(), 'treeseed-host-client-'));
+	const socket = join(root, 'manager.sock'); let requests = 0;
+	const server = createServer((request, response) => {
+		request.resume(); request.on('end', () => {
+			requests += 1; response.setHeader('content-type', 'application/json');
+			response.end(JSON.stringify({ ok: true, data: { request: requests }, error: null }));
+		});
+	});
+	server.keepAliveTimeout = 1;
+	await new Promise<void>((resolve) => server.listen(socket, resolve));
+	try {
+		assert.deepEqual(await invokeLocalHostManager({ operation: 'first' }, socket), { request: 1 });
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		assert.deepEqual(await invokeLocalHostManager({ operation: 'second' }, socket), { request: 2 });
+	} finally {
+		await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+		rmSync(root, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
Uses fresh manager Unix sockets across long builds, makes dev rebuild --plan non-mutating, and adds opt-in stack diagnostics.\n\nVerified locally: CLI lint and 68 tests; real candidate rebuild and plan smoke tests.