### PR TITLE
Preserve Platform verification diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.39",
+  "version": "0.13.0-rc.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.39",
+      "version": "0.13.0-rc.40",
       "bundleDependencies": [
         "ink",
         "react",
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.61",
+        "@treeseed/sdk": "0.13.0-rc.63",
         "ink": "^7.1.1",
         "react": "^19.2.8",
         "string-width": "^8.2.2",
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.61",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.61.tgz",
-      "integrity": "sha512-Op9t955kwz750YzSG7F458ZEBvGMgMITgj64k8WSAbys1r0XT37OVv98wzTaKRLgvbEOTDrgRUdBiKsLJsbtKw==",
+      "version": "0.13.0-rc.63",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.63.tgz",
+      "integrity": "sha512-YfZVOb2Q1+8hvyzBYd/swi32vGIwY5PjlYK8J8i93LsJEgqKdxmGbOT/gFEf0XPJoQAffiN2vEVONAUX/YEjNw==",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",
         "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.39",
+  "version": "0.13.0-rc.40",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -50,7 +50,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.61",
+    "@treeseed/sdk": "0.13.0-rc.63",
     "ink": "^7.1.1",
     "react": "^19.2.8",
     "string-width": "^8.2.2",
@@ -74,5 +74,11 @@
   },
   "bin": {
     "trsd": "./dist/cli/main.js"
-  }
+  },
+  "bundleDependencies": [
+    "ink",
+    "react",
+    "string-width",
+    "yaml"
+  ]
 }

--- a/src/cli/commands/platform/index.ts
+++ b/src/cli/commands/platform/index.ts
@@ -14,7 +14,11 @@ function verify(invocation: ParsedInvocation, context: CommandContext) {
 	const profiles = loadPlatformProfiles(root);
 	const selected = values(invocation.options.profile);
 	if (selected.length) resolveProfileProjects(profiles, selected);
-	return { ...verifyPlatformRepository(root), profiles: selected };
+	const result = { ...verifyPlatformRepository(root), profiles: selected };
+	if (!result.ok) throw Object.assign(new Error('Platform repository verification failed.'), {
+		category: 'policy_blocked', code: 'platform_verification_failed', partialResult: result,
+	});
+	return result;
 }
 
 function workset(invocation: ParsedInvocation, context: CommandContext) {

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -106,8 +106,9 @@ export async function runCommandLine(argv: string[], overrides: Partial<CommandC
 	try {
 		const response = await execute(invocation, context);
 		const api = response && typeof response === 'object' ? response as { ok?: boolean; payload?: unknown; code?: string; error?: string } : null;
-		if (api?.ok === false) { const failed = failure('policy_blocked', api.code ?? 'control_plane_rejected', api.error ?? 'The control plane rejected the operation.'); print(context, envelope(invocation, false, null, failed), false); return 1; }
-		const result = api && 'payload' in api ? api.payload : response && typeof response === 'object' && 'data' in response ? (response as { data: unknown }).data : response;
+		const operationResponse = invocation.command.execution.kind === 'operation';
+		if (operationResponse && api?.ok === false) { const failed = failure('policy_blocked', api.code ?? 'control_plane_rejected', api.error ?? 'The control plane rejected the operation.'); print(context, envelope(invocation, false, null, failed), false); return 1; }
+		const result = operationResponse && api && 'payload' in api ? api.payload : response && typeof response === 'object' && 'data' in response ? (response as { data: unknown }).data : response;
 		print(context, envelope(invocation, true, result)); return 0;
 	} catch (error) {
 		if (context.env.TREESEED_DEBUG_STACK === '1' && error instanceof Error && error.stack) context.write(error.stack, 'stderr');

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -9,7 +9,7 @@ test('package has one executable and only its declared CLI runtime dependencies'
 	assert.equal(pkg.types, undefined);
 	assert.equal(pkg.files.some((path: string) => path.startsWith('scripts/')), false);
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.61', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.63', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
 });
 
 test('built package contains executable runtime only', () => {

--- a/tests/unit/command-boundary/platform/workset.test.ts
+++ b/tests/unit/command-boundary/platform/workset.test.ts
@@ -12,14 +12,31 @@ test('platform verify works from a clean declarative clone without packages or a
 	const root = mkdtempSync(resolve(tmpdir(), 'platform-cli-'));
 	try {
 		execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
+		mkdirSync(resolve(root, 'seeds'));
 		writeFileSync(resolve(root, 'README.md'), '# Portable Platform\n');
 		writeFileSync(resolve(root, 'treeseed.site.yaml'), 'development:\n  local:\n    inventory: { source: seed, path: seeds/inventory.yaml }\n');
+		writeFileSync(resolve(root, 'seeds/inventory.yaml'), 'schemaVersion: treeseed.seed-bundle/v3\nresources:\n  projects: []\n  repositories: []\n');
 		execFileSync('git', ['add', '.'], { cwd: root, stdio: 'ignore' });
 		const target = capture();
-		assert.equal(await runCommandLine(['platform', 'verify', '--json'], { cwd: root, interactiveUi: false, write: target.write }), 0);
+		assert.equal(await runCommandLine(['platform', 'verify', '--json'], { cwd: root, interactiveUi: false, write: target.write }), 0, target.output.join('\n'));
 		const envelope = JSON.parse(target.output[0]!);
 		assert.equal(envelope.result.ok, true);
 		assert.equal(envelope.result.profiles.length, 0);
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('platform verify preserves local policy diagnostics instead of masking them as a control-plane rejection', async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'platform-cli-'));
+	try {
+		execFileSync('git', ['init'], { cwd: root, stdio: 'ignore' });
+		writeFileSync(resolve(root, 'package.json'), '{}\n');
+		execFileSync('git', ['add', '.'], { cwd: root, stdio: 'ignore' });
+		const target = capture();
+		assert.equal(await runCommandLine(['platform', 'verify', '--json'], { cwd: root, interactiveUi: false, write: target.write }), 1);
+		const envelope = JSON.parse(target.output[0]!);
+		assert.equal(envelope.error.code, 'platform_verification_failed');
+		assert.equal(envelope.result.diagnostics[0].code, 'content_root_forbidden');
+		assert.notEqual(envelope.error.code, 'control_plane_rejected');
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
Closes #88

## Outcome

Makes remote-envelope interpretation specific to catalog operations and preserves failed local Platform verification as a typed nonzero result with its exact SDK diagnostics.

## Exact inputs

- CLI base `b67a9a7600f79a2c5e9bb4397fa527b083b6e22e` (`0.13.0-rc.39`)
- SDK `0.13.0-rc.63` at `f3e615c88224069d15b44b9171da20539ba173e3`

## Verification

- 71 CLI tests pass.
- Clean declarative verification, diagnostic preservation, exact workset apply/replay, package policy, and packed-install smoke pass.
- Full release verification passes.
- Version is batched as `0.13.0-rc.40`.

## Rollback

Revert the local/operation response classification and Platform handler changes.