### PR TITLE
Fix host uninstall authorization forwarding

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -2199,7 +2199,7 @@ Operation: read. Result schema: `treeseed.command.library.show/v1`.
 Execution: `local.library.show`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Earlier historical revision; omit for the current library.
+- `--ref <value>`: Exact commit or protected library ref.
 
 ### trsd library status <project>
 
@@ -2209,7 +2209,7 @@ Operation: read. Result schema: `treeseed.command.library.status/v1`.
 Execution: `local.library.status`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Earlier historical revision; omit for the current library.
+- `--ref <value>`: Exact commit or protected library ref.
 
 ### trsd library paths <project>
 
@@ -2219,7 +2219,7 @@ Operation: read. Result schema: `treeseed.command.library.paths/v1`.
 Execution: `local.library.paths`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Earlier historical revision; omit for the current library.
+- `--ref <value>`: Exact commit or protected library ref.
 - `--prefix <value>`: Repository-relative path prefix.
 - `--limit <value>`: Page size.
 - `--cursor <value>`: Opaque page cursor.
@@ -2232,7 +2232,7 @@ Operation: read. Result schema: `treeseed.command.library.read/v1`.
 Execution: `local.library.read`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Earlier historical revision; omit for the current library.
+- `--ref <value>`: Exact commit or protected library ref.
 
 ### trsd library search <project> <query>
 
@@ -2242,7 +2242,7 @@ Operation: read. Result schema: `treeseed.command.library.search/v1`.
 Execution: `local.library.search`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Earlier historical revision; omit for the current library.
+- `--ref <value>`: Exact commit or protected library ref.
 - `--path <value>`: Restrict search to a repository-relative path.
 - `--limit <value>`: Page size.
 - `--cursor <value>`: Opaque page cursor.
@@ -2255,7 +2255,7 @@ Operation: read. Result schema: `treeseed.command.library.query/v1`.
 Execution: `local.library.query`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Earlier historical revision; omit for the current library.
+- `--ref <value>`: Exact commit or protected library ref.
 - `--model <value>`: TreeDX content model.
 - `--input <value>`: YAML or JSON query body.
 
@@ -2267,7 +2267,7 @@ Operation: read. Result schema: `treeseed.command.library.context/v1`.
 Execution: `local.library.context`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Earlier historical revision; omit for the current library.
+- `--ref <value>`: Exact commit or protected library ref.
 - `--max-items <value>`: Maximum context items.
 - `--max-tokens <value>`: Maximum context tokens.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.42",
+  "version": "0.13.0-rc.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.42",
+      "version": "0.13.0-rc.43",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.42",
+  "version": "0.13.0-rc.43",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/schemas/command-tree.json
+++ b/schemas/command-tree.json
@@ -5469,7 +5469,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Earlier historical revision; omit for the current library.",
+              "description": "Exact commit or protected library ref.",
               "type": "string"
             }
           ],
@@ -5494,7 +5494,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Earlier historical revision; omit for the current library.",
+              "description": "Exact commit or protected library ref.",
               "type": "string"
             }
           ],
@@ -5519,7 +5519,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Earlier historical revision; omit for the current library.",
+              "description": "Exact commit or protected library ref.",
               "type": "string"
             },
             {
@@ -5564,7 +5564,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Earlier historical revision; omit for the current library.",
+              "description": "Exact commit or protected library ref.",
               "type": "string"
             }
           ],
@@ -5594,7 +5594,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Earlier historical revision; omit for the current library.",
+              "description": "Exact commit or protected library ref.",
               "type": "string"
             },
             {
@@ -5639,7 +5639,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Earlier historical revision; omit for the current library.",
+              "description": "Exact commit or protected library ref.",
               "type": "string"
             },
             {
@@ -5679,7 +5679,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Earlier historical revision; omit for the current library.",
+              "description": "Exact commit or protected library ref.",
               "type": "string"
             },
             {

--- a/src/cli/commands/host.ts
+++ b/src/cli/commands/host.ts
@@ -73,6 +73,7 @@ async function input(invocation: ParsedInvocation, context: CommandContext) {
 				category: 'confirmation_required', code: 'confirmation_required',
 			});
 		}
+		options.yes = true;
 	}
 	if (invocation.command.name === 'host provider credentials initialize') {
 		const initializerId = invocation.arguments[0];

--- a/tests/unit/command-boundary/host-storage-reset.test.ts
+++ b/tests/unit/command-boundary/host-storage-reset.test.ts
@@ -64,5 +64,5 @@ test('host uninstall preserves explicit security purge authorization', async () 
 		write() {},
 	});
 	assert.equal(exit, 0);
-	assert.deepEqual(calls, [{ handlerId: 'local.host.uninstall', arguments: [], options: { confirm: true, purgeSecurity: true } }]);
+	assert.deepEqual(calls, [{ handlerId: 'local.host.uninstall', arguments: [], options: { confirm: true, purgeSecurity: true, yes: true } }]);
 });


### PR DESCRIPTION
Closes #96.

The CLI now preserves the already-validated `--yes` authorization when invoking the protected manager uninstall boundary. Plan and incomplete-confirmation behavior remain fail-closed. This also regenerates command documentation from the current protected SDK catalog and bumps the candidate to `0.13.0-rc.43`.

Verification: `npm run verify:direct` (78 tests plus packed-install smoke and artifact pack).