### PR TITLE
Bind host initialization execute to exact catalog plan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.43",
+  "version": "0.13.0-rc.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.43",
+      "version": "0.13.0-rc.44",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.43",
+  "version": "0.13.0-rc.44",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/host.ts
+++ b/src/cli/commands/host.ts
@@ -49,7 +49,16 @@ async function input(invocation: ParsedInvocation, context: CommandContext) {
 			throw Object.assign(new Error('Host initialize execution requires both --confirm and --yes after reviewing the plan.'), { category: 'confirmation_required', code: 'confirmation_required' });
 		}
 		const planCommand = { handlerId: invocation.command.execution.handlerId, arguments: [], options: { plan: true, profile } };
-		const planned = await (context.hostInvoke ? context.hostInvoke(planCommand) : invokeLocalHostManager(planCommand)) as { inputs?: Array<{ name: string; required: boolean; sensitive: boolean; description: string }> };
+		const planned = await (context.hostInvoke ? context.hostInvoke(planCommand) : invokeLocalHostManager(planCommand)) as {
+			hostId?: unknown; catalog?: { release?: unknown; generation?: unknown; digest?: unknown };
+			inputs?: Array<{ name: string; required: boolean; sensitive: boolean; description: string }>;
+		};
+		if (typeof planned.hostId !== 'string' || !/^[a-z][a-z0-9.-]{1,63}$/u.test(planned.hostId)) throw new Error('Host initialization plan contains an invalid runtime host identity.');
+		if (!planned.catalog || typeof planned.catalog.release !== 'string' || !planned.catalog.release
+			|| !Number.isInteger(planned.catalog.generation) || Number(planned.catalog.generation) <= 0
+			|| typeof planned.catalog.digest !== 'string' || !/^sha256:[a-f0-9]{64}$/u.test(planned.catalog.digest)) {
+			throw new Error('Host initialization plan does not contain a valid immutable catalog binding.');
+		}
 		const values: Record<string, string> = {};
 		for (const descriptor of planned.inputs ?? []) {
 			if (!/^[a-z][A-Za-z0-9]{1,63}$/u.test(descriptor.name)) throw new Error('Host initialization plan contains an invalid input descriptor.');
@@ -65,7 +74,9 @@ async function input(invocation: ParsedInvocation, context: CommandContext) {
 			}
 			if (value) values[descriptor.name] = value;
 		}
-		return { handlerId: invocation.command.execution.handlerId, arguments: [], options: { profile, confirm: true, payload: JSON.stringify({ profile, inputs: values }) } };
+		return { handlerId: invocation.command.execution.handlerId, arguments: [], options: { profile, confirm: true, payload: JSON.stringify({
+			profile, hostId: planned.hostId, catalog: { release: planned.catalog.release, generation: planned.catalog.generation, digest: planned.catalog.digest }, inputs: values,
+		}) } };
 	}
 	if (invocation.command.name === 'host uninstall' && invocation.options.plan !== true) {
 		if (invocation.options.confirm !== true || invocation.options.yes !== true) {

--- a/tests/unit/command-boundary/host/initialize.test.ts
+++ b/tests/unit/command-boundary/host/initialize.test.ts
@@ -20,7 +20,7 @@ test('host initialize prompts from the manager plan and keeps secrets out of arg
 		interactiveUi: false, prompt: async () => 'https://api.example.test', promptSecret: async () => secret,
 		hostInvoke: async (request) => {
 			calls.push(request);
-			if (request.options.plan === true) return { inputs: [
+			if (request.options.plan === true) return { hostId: 'provider-01', catalog: { release: '0.1.0~rc200', generation: 160, digest: `sha256:${'a'.repeat(64)}` }, inputs: [
 				{ name: 'controlPlaneUrl', required: true, sensitive: false, description: 'Control plane URL' },
 				{ name: 'teamRegistrationCode', required: true, sensitive: true, description: 'Team registration code' },
 			] };
@@ -29,8 +29,19 @@ test('host initialize prompts from the manager plan and keeps secrets out of arg
 	});
 	assert.equal(exit, 0); assert.equal(calls.length, 2);
 	assert.deepEqual(calls[0], { handlerId: 'local.host.initialize', arguments: [], options: { plan: true, profile: 'capacity-provider' } });
-	assert.deepEqual(JSON.parse(calls[1].options.payload), { profile: 'capacity-provider', inputs: { controlPlaneUrl: 'https://api.example.test', teamRegistrationCode: secret } });
+	assert.deepEqual(JSON.parse(calls[1].options.payload), { profile: 'capacity-provider', hostId: 'provider-01',
+		catalog: { release: '0.1.0~rc200', generation: 160, digest: `sha256:${'a'.repeat(64)}` },
+		inputs: { controlPlaneUrl: 'https://api.example.test', teamRegistrationCode: secret } });
 	assert.equal(JSON.stringify(output).includes(secret), false);
+});
+
+test('host initialize rejects a missing immutable plan binding before prompting', async () => {
+	let prompts = 0; let calls = 0;
+	const exit = await runCommandLine(['host', 'initialize', '--profile', 'core', '--confirm', '--yes', '--json'], {
+		interactiveUi: false, prompt: async () => { prompts += 1; return ''; }, promptSecret: async () => { prompts += 1; return ''; },
+		hostInvoke: async () => { calls += 1; return { hostId: 'runtime-host', inputs: [] }; }, write() {},
+	});
+	assert.equal(exit, 1); assert.equal(calls, 1); assert.equal(prompts, 0);
 });
 
 test('host initialize rejects incomplete execution confirmation before manager invocation', async () => {

--- a/tests/unit/command-boundary/users-create.test.ts
+++ b/tests/unit/command-boundary/users-create.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { runCommandLine } from '../../../src/cli/runtime.ts';
 
-const identity = ['users', 'create', '--email', 'adrian.webb@knowledge.coop', '--username', 'adrian', '--display-name', 'Adrian Webb'];
+const identity = ['users', 'create', '--email', 'operator@example.test', '--username', 'operator', '--display-name', 'Test Operator'];
 
 test('users create securely prompts twice and invokes the anonymous registration operation', async () => {
 	const output: string[] = [];
@@ -13,13 +13,13 @@ test('users create securely prompts twice and invokes the anonymous registration
 		promptSecret: async () => prompts.shift() ?? '',
 		operationInvoke: async (operationId, input) => {
 			calls.push({ operationId, input });
-			return { data: { confirmationRequired: true, email: 'adrian.webb@knowledge.coop' } };
+			return { data: { confirmationRequired: true, email: 'operator@example.test' } };
 		},
 		write: (value) => output.push(value),
 	});
 	assert.equal(exit, 0);
 	assert.equal(calls[0]?.operationId, 'accounts.register');
-	assert.deepEqual(calls[0]?.input, { path: {}, query: {}, body: { email: 'adrian.webb@knowledge.coop', username: 'adrian', displayName: 'Adrian Webb', password: 'a sufficiently long password' } });
+	assert.deepEqual(calls[0]?.input, { path: {}, query: {}, body: { email: 'operator@example.test', username: 'operator', displayName: 'Test Operator', password: 'a sufficiently long password' } });
 	assert.doesNotMatch(output[0]!, /sufficiently long password/u);
 	assert.match(JSON.parse(output[0]!).result.nextAction, /mail\.treeseed\.localhost/u);
 });
@@ -49,11 +49,11 @@ test('users create prints an explicit success result in human mode', async () =>
 	const exit = await runCommandLine(identity, {
 		interactiveUi: false,
 		promptSecret: async () => prompts.shift() ?? '',
-		operationInvoke: async () => ({ data: { confirmationRequired: true, email: 'adrian.webb@knowledge.coop' } }),
+		operationInvoke: async () => ({ data: { confirmationRequired: true, email: 'operator@example.test' } }),
 		write: (value) => output.push(value),
 	});
 	assert.equal(exit, 0);
-	assert.match(output[0]!, /User registration accepted for adrian\.webb@knowledge\.coop\./u);
+	assert.match(output[0]!, /User registration accepted for operator@example\.test\./u);
 });
 
 test('users create rejects mismatched passwords without invoking the API or leaking either value', async () => {


### PR DESCRIPTION
Closes #98

## Contract
- validate runtime host identity and immutable catalog binding returned by the plan
- forward the exact reviewed binding to execution
- keep sensitive initialization inputs out of argv and structured output
- reject incomplete or moved plans before prompting or mutation

## Verification
- `npm run verify:direct`
- 79 direct tests and packed-install smoke pass locally