### PR TITLE
Classify host security prerequisites as policy blockers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.44",
+  "version": "0.13.0-rc.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.44",
+      "version": "0.13.0-rc.45",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.44",
+  "version": "0.13.0-rc.45",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -41,6 +41,7 @@ function categorized(error: unknown): CommandFailure {
 	if (value.category) return failure(value.category, value.code ?? 'command_failed', value.message ?? String(error));
 	const code = value.problem?.code ?? value.code ?? 'command_failed';
 	const message = value.problem?.detail ?? value.problem?.title ?? value.message ?? String(error);
+	if (code === 'host_security_initialization_required') return failure('policy_blocked', code, message);
 	if (code === 'confirmation_required' || code === 'confirmation_invalid') return failure('confirmation_required', code, message);
 	if (code === 'stale_preflight') return failure('stale_preflight', code, message);
 	if (value.status === 400 || value.status === 412) return failure('invalid_input', code, message);

--- a/tests/unit/command-boundary/host/security-prerequisite.test.ts
+++ b/tests/unit/command-boundary/host/security-prerequisite.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runCommandLine } from '../../../../src/cli/runtime.ts';
+
+test('host security prerequisites remain actionable policy blockers', async () => {
+	const output: string[] = [];
+	const exit = await runCommandLine(['host', 'update', 'apply', '--yes', '--json'], {
+		interactiveUi: false,
+		hostInvoke: async () => { throw Object.assign(new Error('Run `trsd host security initialize` and replay the accepted update.'), { status: 409, code: 'host_security_initialization_required' }); },
+		write: (value) => output.push(value),
+	});
+	assert.equal(exit, 1);
+	assert.deepEqual(JSON.parse(output[0]!).error, {
+		category: 'policy_blocked',
+		code: 'host_security_initialization_required',
+		message: 'Run `trsd host security initialize` and replay the accepted update.',
+	});
+});


### PR DESCRIPTION
## Objective

Preserve the manager-owned `host_security_initialization_required` contract as an actionable CLI policy blocker during managed host updates.

## Behavior

- The stable manager code maps to `policy_blocked`.
- JSON output preserves the stable code and actionable message.
- No secret, hostname, username, recovery path, or host-specific value is emitted.
- CLI advances to `0.13.0-rc.45` for immutable publication and Deployment consumption.

## Verification

- File architecture/length and distribution build pass.
- Full release verification passes 80 tests.
- Packed artifact verification passes.

## Rollback

Revert this change; the manager still blocks activation, but older clients classify HTTP 409 as a generic conflict.

Tracks #86 and treeseed-ai/deployment#385.