### PR TITLE
feat(platform): reconcile custom projects through API

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -2199,7 +2199,7 @@ Operation: read. Result schema: `treeseed.command.library.show/v1`.
 Execution: `local.library.show`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Exact commit or protected library ref.
+- `--ref <value>`: Earlier historical revision; omit for the current library.
 
 ### trsd library status <project>
 
@@ -2209,7 +2209,7 @@ Operation: read. Result schema: `treeseed.command.library.status/v1`.
 Execution: `local.library.status`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Exact commit or protected library ref.
+- `--ref <value>`: Earlier historical revision; omit for the current library.
 
 ### trsd library paths <project>
 
@@ -2219,7 +2219,7 @@ Operation: read. Result schema: `treeseed.command.library.paths/v1`.
 Execution: `local.library.paths`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Exact commit or protected library ref.
+- `--ref <value>`: Earlier historical revision; omit for the current library.
 - `--prefix <value>`: Repository-relative path prefix.
 - `--limit <value>`: Page size.
 - `--cursor <value>`: Opaque page cursor.
@@ -2232,7 +2232,7 @@ Operation: read. Result schema: `treeseed.command.library.read/v1`.
 Execution: `local.library.read`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Exact commit or protected library ref.
+- `--ref <value>`: Earlier historical revision; omit for the current library.
 
 ### trsd library search <project> <query>
 
@@ -2242,7 +2242,7 @@ Operation: read. Result schema: `treeseed.command.library.search/v1`.
 Execution: `local.library.search`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Exact commit or protected library ref.
+- `--ref <value>`: Earlier historical revision; omit for the current library.
 - `--path <value>`: Restrict search to a repository-relative path.
 - `--limit <value>`: Page size.
 - `--cursor <value>`: Opaque page cursor.
@@ -2255,7 +2255,7 @@ Operation: read. Result schema: `treeseed.command.library.query/v1`.
 Execution: `local.library.query`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Exact commit or protected library ref.
+- `--ref <value>`: Earlier historical revision; omit for the current library.
 - `--model <value>`: TreeDX content model.
 - `--input <value>`: YAML or JSON query body.
 
@@ -2267,7 +2267,7 @@ Operation: read. Result schema: `treeseed.command.library.context/v1`.
 Execution: `local.library.context`.
 
 - `--json`: Emit the stable JSON envelope.
-- `--ref <value>`: Exact commit or protected library ref.
+- `--ref <value>`: Earlier historical revision; omit for the current library.
 - `--max-items <value>`: Maximum context items.
 - `--max-tokens <value>`: Maximum context tokens.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.45",
+  "version": "0.13.0-rc.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.45",
+      "version": "0.13.0-rc.46",
       "bundleDependencies": [
         "ink",
         "react",
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.65",
+        "@treeseed/sdk": "0.13.0-rc.68",
         "ink": "^7.1.1",
         "react": "^19.2.8",
         "string-width": "^8.2.2",
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.65",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.65.tgz",
-      "integrity": "sha512-McRysmZzEXylsPKdIPxbO7Q3HnWKV0qnDrc54p87iUsIpiupe4YjPORTNyjcKG4YEyM1eQ6P72XkESnxgBxR+w==",
+      "version": "0.13.0-rc.68",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.68.tgz",
+      "integrity": "sha512-+JqLGWlptwrjjovcVxVbSIviERM1koyiTBZyfSKvwfY47ty4cxw5GjzTRrSIJuAcB7YmVY7VfABrpZ04WzJYEw==",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",
         "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.45",
+  "version": "0.13.0-rc.46",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -50,7 +50,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.65",
+    "@treeseed/sdk": "0.13.0-rc.68",
     "ink": "^7.1.1",
     "react": "^19.2.8",
     "string-width": "^8.2.2",

--- a/schemas/command-tree.json
+++ b/schemas/command-tree.json
@@ -5469,7 +5469,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Exact commit or protected library ref.",
+              "description": "Earlier historical revision; omit for the current library.",
               "type": "string"
             }
           ],
@@ -5494,7 +5494,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Exact commit or protected library ref.",
+              "description": "Earlier historical revision; omit for the current library.",
               "type": "string"
             }
           ],
@@ -5519,7 +5519,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Exact commit or protected library ref.",
+              "description": "Earlier historical revision; omit for the current library.",
               "type": "string"
             },
             {
@@ -5564,7 +5564,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Exact commit or protected library ref.",
+              "description": "Earlier historical revision; omit for the current library.",
               "type": "string"
             }
           ],
@@ -5594,7 +5594,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Exact commit or protected library ref.",
+              "description": "Earlier historical revision; omit for the current library.",
               "type": "string"
             },
             {
@@ -5639,7 +5639,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Exact commit or protected library ref.",
+              "description": "Earlier historical revision; omit for the current library.",
               "type": "string"
             },
             {
@@ -5679,7 +5679,7 @@
           "options": [
             {
               "name": "--ref",
-              "description": "Exact commit or protected library ref.",
+              "description": "Earlier historical revision; omit for the current library.",
               "type": "string"
             },
             {

--- a/src/cli/commands/platform/index.ts
+++ b/src/cli/commands/platform/index.ts
@@ -1,9 +1,15 @@
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { applyPlatformWorkset, loadPlatformInventory, loadPlatformProfiles, planPlatformWorkset, resolveProfileProjects, verifyPlatformRepository } from '@treeseed/sdk/platform';
+import { parse as parseYaml } from 'yaml';
+import { applyPlatformWorkset, loadPlatformInventory, loadPlatformProfiles, planPlatformWorkset, projectCreatePlanSchema, resolveProfileProjects, verifyPlatformRepository } from '@treeseed/sdk/platform';
+import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
 import type { CommandContext, ParsedInvocation } from '../../types.js';
+import { createControlPlaneClient } from '../../support/client.js';
 
 const values = (value: string | string[] | boolean | undefined) => Array.isArray(value) ? value : typeof value === 'string' ? [value] : [];
 const invalid = (code: string, message: string) => Object.assign(new Error(message), { category: 'invalid_input', code });
+const payload = (value: unknown) => value && typeof value === 'object' && !Array.isArray(value) && 'data' in value ? (value as { data: unknown }).data : value;
 
 function rootFor(invocation: ParsedInvocation, context: CommandContext) {
 	return resolve(context.cwd, invocation.arguments[0] ?? '.');
@@ -37,21 +43,42 @@ function workset(invocation: ParsedInvocation, context: CommandContext) {
 	return applyPlatformWorkset(plan);
 }
 
-function projectCreate(invocation: ParsedInvocation) {
+function templateLock(root: string, id: string) {
+	if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(id)) throw invalid('template_invalid', 'Template identities use portable lowercase slugs.');
+	const path = resolve(root, 'templates', `${id}.yaml`);
+	const value = parseYaml(readFileSync(path, 'utf8')) as Record<string, unknown>;
+	const artifact = value.artifact && typeof value.artifact === 'object' ? value.artifact as Record<string, unknown> : {};
+	const version = String(value.version ?? ''); const digest = String(artifact.digest ?? '');
+	if (value.schemaVersion !== 'treeseed.platform-template-lock/v1' || value.id !== id || !version || !/^sha256:[0-9a-f]{64}$/u.test(digest)) {
+		throw invalid('template_lock_invalid', `Template lock ${path} is not an exact published template.`);
+	}
+	return { id, version, digest };
+}
+
+async function projectCreate(invocation: ParsedInvocation, context: CommandContext) {
 	const slug = invocation.arguments[0]!;
-	const template = String(invocation.options.template ?? '');
-	if (!template) throw invalid('template_required', '--template is required.');
-	if (invocation.options.plan === true) return {
-		schemaVersion: 'treeseed.platform-project-create-preview/v1', slug, template,
-		steps: ['project', 'repository', 'template', 'library', 'inventory'], mutation: false,
-		blockers: ['control_plane_project_reconciliation_not_published'],
-	};
-	throw Object.assign(new Error('Project creation apply remains fail-closed until its control-plane reconciliation operation is published.'), { category: 'policy_blocked', code: 'control_plane_project_reconciliation_not_published' });
+	const templateId = String(invocation.options.template ?? '');
+	if (!templateId) throw invalid('template_required', '--template is required.');
+	const planning = invocation.options.plan === true; const applying = invocation.options.apply === true;
+	if (planning === applying) throw invalid('project_create_mode_required', 'Choose exactly one of --plan or --apply.');
+	if (applying && invocation.options.yes !== true) throw Object.assign(new Error('Project creation apply requires --yes after reviewing the plan.'), { category: 'confirmation_required', code: 'confirmation_required' });
+	const template = templateLock(context.cwd, templateId);
+	let teamId = String(context.env.TREESEED_TEAM_ID ?? ''); let invoke: (body: Record<string, unknown>, apply: boolean) => Promise<unknown>;
+	if (context.operationInvoke) invoke = (body) => context.operationInvoke!('projects.create', { path: { teamId }, query: {}, body });
+	else {
+		const { client, session } = await createControlPlaneClient(invocation, context, true); teamId = String(session?.activeTeam?.id ?? '');
+		invoke = (body, apply) => client.invoke(CONTROL_PLANE_OPERATIONS.projects.create, { path: { teamId }, query: {}, body }, apply ? { idempotencyKey: randomUUID(), headers: {} } : undefined);
+	}
+	if (!teamId) throw Object.assign(new Error('Select an active team with `trsd teams use <team>` before creating a project.'), { category: 'ambiguous_context', code: 'active_team_required' });
+	const plan = projectCreatePlanSchema.parse(payload(await invoke({ mode: 'plan', target: { slug, template, repository: { name: slug, visibility: 'private' } } }, false)));
+	if (planning) return plan;
+	if (!plan.ok) throw Object.assign(new Error('Project creation is blocked by conflicting remote authority.'), { category: 'policy_blocked', code: 'platform_project_create_blocked', partialResult: plan });
+	return payload(await invoke({ mode: 'apply', plan }, true));
 }
 
 export function runPlatform(invocation: ParsedInvocation, context: CommandContext) {
 	if (invocation.command.name === 'platform verify') return verify(invocation, context);
 	if (invocation.command.name === 'platform workset') return workset(invocation, context);
-	if (invocation.command.name === 'platform project create') return projectCreate(invocation);
+	if (invocation.command.name === 'platform project create') return projectCreate(invocation, context);
 	throw invalid('platform_command_unknown', `Unsupported Platform command ${invocation.command.name}.`);
 }

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -9,7 +9,7 @@ test('package has one executable and only its declared CLI runtime dependencies'
 	assert.equal(pkg.types, undefined);
 	assert.equal(pkg.files.some((path: string) => path.startsWith('scripts/')), false);
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.65', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.68', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
 });
 
 test('built package contains executable runtime only', () => {

--- a/tests/unit/command-boundary/platform/project-create.test.ts
+++ b/tests/unit/command-boundary/platform/project-create.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import { runCommandLine } from '../../../../src/cli/runtime.ts';
+
+const digest = `sha256:${'b'.repeat(64)}`;
+const plan = { schemaVersion: 'treeseed.platform-project-create-plan/v1', slug: 'example-app', template: { id: 'engineering', version: '1.0.0-rc.5', digest }, team: 'team-1',
+	repository: { owner: 'example', name: 'example-app', visibility: 'private' }, steps: ['project', 'repository', 'template', 'library', 'inventory'],
+	actions: ['project', 'repository', 'template', 'library', 'inventory'].map((step, index) => ({ step, action: ['create', 'adopt', 'apply', 'bind', 'publish'][index] })),
+	observationDigest: digest, planDigest: digest, ok: true, blockers: [] };
+
+function fixture() {
+	const root = mkdtempSync(resolve(tmpdir(), 'platform-project-create-')); mkdirSync(resolve(root, 'templates'));
+	writeFileSync(resolve(root, 'templates/engineering.yaml'), `schemaVersion: treeseed.platform-template-lock/v1\nid: engineering\nversion: 1.0.0-rc.5\nartifact:\n  digest: ${digest}\n`);
+	return root;
+}
+
+test('platform project create plans through API authority without mutation', async () => {
+	const root = fixture(); const calls: any[] = []; const output: string[] = [];
+	try {
+		const exit = await runCommandLine(['platform', 'project', 'create', 'example-app', '--template', 'engineering', '--plan', '--json'], {
+			cwd: root, env: { TREESEED_TEAM_ID: 'team-1' }, interactiveUi: false, write: (value) => output.push(value),
+			operationInvoke: async (operationId, input) => { calls.push({ operationId, input }); return { data: plan }; },
+		});
+		assert.equal(exit, 0, output.join('\n')); assert.equal(calls.length, 1); assert.equal(calls[0].input.body.mode, 'plan');
+		assert.equal(JSON.parse(output[0]!).result.planDigest, digest);
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('platform project create applies the exact API plan and never writes application source locally', async () => {
+	const root = fixture(); const calls: any[] = []; const output: string[] = [];
+	try {
+		const exit = await runCommandLine(['platform', 'project', 'create', 'example-app', '--template', 'engineering', '--apply', '--yes', '--json'], {
+			cwd: root, env: { TREESEED_TEAM_ID: 'team-1' }, interactiveUi: false, write: (value) => output.push(value),
+			operationInvoke: async (operationId, input: any) => { calls.push({ operationId, input }); return input.body.mode === 'plan' ? { data: plan } : { data: { ...plan, schemaVersion: 'treeseed.platform-project-create-receipt/v1', projectId: 'project-1' } }; },
+		});
+		assert.equal(exit, 0, output.join('\n')); assert.deepEqual(calls.map((call) => call.input.body.mode), ['plan', 'apply']);
+		assert.equal(calls[1].input.body.plan.planDigest, digest); assert.equal(JSON.parse(output[0]!).result.projectId, 'project-1');
+		assert.equal(await import('node:fs').then(({ existsSync }) => existsSync(resolve(root, 'packages/example-app'))), false);
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
Closes #85

## Outcome

Publishes CLI `0.13.0-rc.46` with functional `trsd platform project create <slug> --template <id> --plan|--apply`. It reads an immutable declarative Platform template lock, uses the active team, obtains an authority-frozen API plan, requires `--yes` for apply, submits the exact plan, and never writes application source into Platform Git.

## Dependencies

- SDK `0.13.0-rc.68`
- API `0.8.0-rc.63` owner implementation (API #165)
- Engineering template `template/1.0.0-rc.5`

## Verification

- 82 CLI tests passed
- build, generated command reference/schema, file-length, and architecture gates passed
- plan invokes API exactly once
- apply invokes plan then exact apply and does not create `packages/<slug>` locally