### PR TITLE
Allow zero-argument provider environment listing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.47",
+  "version": "0.13.0-rc.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.47",
+      "version": "0.13.0-rc.48",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.47",
+  "version": "0.13.0-rc.48",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/host.ts
+++ b/src/cli/commands/host.ts
@@ -51,6 +51,9 @@ async function standardInput(context: CommandContext) {
 
 async function providerEnvironmentInput(invocation: ParsedInvocation, context: CommandContext, options: Record<string, string | string[] | boolean | undefined>) {
 	const [profileId, name] = invocation.arguments;
+	if (invocation.command.name === 'host provider environment list') {
+		return { handlerId: invocation.command.execution.kind === 'local' ? invocation.command.execution.handlerId : '', arguments: [], options };
+	}
 	if (!profileId) throw Object.assign(new Error('A provider-local environment profile is required.'), { category: 'invalid_input', code: 'provider_environment_profile_required' });
 	if (invocation.command.name === 'host provider environment import') {
 		if (invocation.options.plan === true) return { handlerId: invocation.command.execution.kind === 'local' ? invocation.command.execution.handlerId : '', arguments: [profileId], options };

--- a/tests/unit/command-boundary/host/provider-environment.test.ts
+++ b/tests/unit/command-boundary/host/provider-environment.test.ts
@@ -45,6 +45,18 @@ test('provider environment set uses hidden input and never emits the value', asy
 	assert.equal(hostUsesProtectedLocalTransport({ command: { name: 'host provider environment set' } as any }), true);
 });
 
+test('provider environment list accepts no profile argument', async () => {
+	const calls: any[] = [];
+	const exit = await runCommandLine(['host', 'provider', 'environment', 'list', '--json'], {
+		interactiveUi: false,
+		hostInvoke: async (input) => { calls.push(input); return { profiles: [] }; },
+		write() {},
+	});
+	assert.equal(exit, 0);
+	assert.equal(calls[0].handlerId, 'local.host.provider.environment.list');
+	assert.deepEqual(calls[0].arguments, []);
+});
+
 test('provider environment rotation accepts standard input without a plaintext argument', async () => {
 	const calls: any[] = [];
 	const exit = await runCommandLine(['host', 'provider', 'environment', 'rotate', 'runtime', 'API_TOKEN', '--stdin', '--json'], {


### PR DESCRIPTION
## Outcome

Corrects the published `host provider environment list` contract so it reaches the protected local manager with no profile argument and returns value-free profile descriptors.

## Work authority

- Work item / Issue: Closes #103
- Proposal / decision: TreeSeed Platform Streamlining and Production-Release Plan
- Assignment / checkpoint: Managed provider-environment acceptance defect
- Actor: Codex
- Human authority: adrian
- Agent / capacity provider: Codex on dev2
- Exact base ref: staging at befe80fce0e68298b46f7935d4f43f036385b424
- Exact head ref: codex/provider-environment-list-103 at 8fee854

Contributor mode (select one):

- [ ] Human-authored
- [x] Agent-assisted under human authority
- [ ] Agent-authored under human authority

## Plan

Special-case the list command before profile validation, preserve every other command boundary, add regression coverage, and publish CLI rc48 through the normal managed updater chain.

## Changes and commits

- Sends empty arguments to local.host.provider.environment.list.
- Keeps profile/name validation unchanged for show, status, verify, import, set, rotate, and unset.
- Advances the replacement candidate to 0.13.0-rc.48.

## Verification

- Complete CLI test run: 87/87 passed.
- Regression proves zero-argument list reaches the expected protected-local handler with empty arguments.
- git diff --check passed.

## Risk and rollback

The change affects only zero-argument list routing. Retain rc47 until rc48 passes Actions, release read-back, Platform composition, and managed-host acceptance.

## Completion summary

Implementation and local verification are complete. Actions, release, composition, and managed acceptance remain.

## Submission checklist

- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.