### PR TITLE
Hydrate exact SDK during CLI promotion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
           test -n "$run_id"
           gh run download "$run_id" --name "cli-candidate-${GITHUB_SHA}" --dir candidate
       - run: npm ci --ignore-scripts --no-audit --no-fund
+      - name: Build the exact Git-pinned SDK distribution
+        run: npm --prefix node_modules/@treeseed/sdk run build:dist
       - run: npm run release:check-tag
       - run: npm run release:custody -- verify candidate/release-evidence-v1.json
       - name: Capture stable tag before publication

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.49",
+  "version": "0.13.0-rc.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.49",
+      "version": "0.13.0-rc.50",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.49",
+  "version": "0.13.0-rc.50",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -24,6 +24,14 @@ test('the executable drains complete output before exiting', () => {
 	assert.equal(main.includes('process.exitCode = await runCommandLine'), true);
 });
 
+test('candidate promotion builds the exact SDK after lifecycle-disabled installation', () => {
+	const workflow = readFileSync('.github/workflows/publish.yml', 'utf8');
+	const install = workflow.indexOf('npm ci --ignore-scripts --no-audit --no-fund');
+	const hydrate = workflow.indexOf('npm --prefix node_modules/@treeseed/sdk run build:dist');
+	const verify = workflow.indexOf('npm run release:custody -- verify');
+	assert.ok(install >= 0 && hydrate > install && verify > hydrate);
+});
+
 test('source contains no legacy implementation residue', () => {
 	const walk = (root: string): string[] => readdirSync(root, { withFileTypes: true }).flatMap((entry) => entry.isDirectory() ? walk(`${root}/${entry.name}`) : [`${root}/${entry.name}`]);
 	const files = walk('src').join('\n');


### PR DESCRIPTION
## Outcome

Repairs CLI promotion by building the exact Git-pinned SDK distribution after lifecycle-disabled installation and prepares replacement candidate rc50.

## Work authority

- Work item / Issue: Closes #111
- Assignment: Hosted production release chain
- Actor: Codex under adrianwebb authority
- Exact base: staging at 0a5e125537ce7648ceb1558b588db8919e789dc3
- Exact head: 3d0e4d848acbd3e81a514d6fe910be65e9dbdf30

## Changes

- Keeps npm ci lifecycle scripts disabled.
- Explicitly runs the exact SDK build before CLI custody verification.
- Adds an ordering contract test.
- Advances the replacement version to 0.13.0-rc.50.

## Verification

- npm run verify:direct passes.
- 91 CLI tests pass, including the new promotion ordering contract.
- Executable artifact packing succeeds.

## Risk and rollback

The only workflow behavior is explicit SDK hydration from the already pinned commit. Keep rc48 selected if protected staging or rc50 publication fails.

## Completion summary

The rc49 release-only failure is addressed without weakening dependency or lifecycle custody.

## Checklist

- [x] Exact refs recorded.
- [x] Failure reproduced from Actions evidence.
- [x] Global lifecycle hooks remain disabled.
- [x] Full verification passes.
- [x] Replacement RC batches the known defect.