### PR TITLE
Install sealed SDK during CLI promotion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,12 @@ jobs:
           run_id="$(gh run list --workflow verify.yml --branch staging --commit "$GITHUB_SHA" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
           test -n "$run_id"
           gh run download "$run_id" --name "cli-candidate-${GITHUB_SHA}" --dir candidate
+      - name: Download the sealed exact SDK candidate
+        run: ./scripts/build/hydrate-exact-sdk.sh candidate/sdk download
+        env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
       - run: npm ci --ignore-scripts --no-audit --no-fund
-      - name: Build the exact Git-pinned SDK distribution
-        run: npm --prefix node_modules/@treeseed/sdk run build:dist
+      - name: Install the sealed exact SDK candidate
+        run: ./scripts/build/hydrate-exact-sdk.sh candidate/sdk install
       - run: npm run release:check-tag
       - run: npm run release:custody -- verify candidate/release-evidence-v1.json
       - name: Capture stable tag before publication

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.50",
+  "version": "0.13.0-rc.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.50",
+      "version": "0.13.0-rc.51",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.50",
+  "version": "0.13.0-rc.51",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/scripts/build/hydrate-exact-sdk.sh
+++ b/scripts/build/hydrate-exact-sdk.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+archive_root="${1:?archive root is required}"
+mode="${2:-install}"
+sdk_sha="$(node -e "const spec=require('./package.json').dependencies['@treeseed/sdk']; const match=spec.match(/#([0-9a-f]{40})$/); process.stdout.write(match?.[1] ?? '');")"
+
+[[ -n "${sdk_sha}" ]]
+mkdir -p "${archive_root}"
+
+select_sdk_archive() {
+  mapfile -t sdk_archives < <(find "${archive_root}" -name 'treeseed-sdk-*.tgz' -type f -print 2>/dev/null | sort)
+  if (( ${#sdk_archives[@]} > 1 )); then
+    echo "Multiple sealed SDK artifacts were found in ${archive_root}." >&2
+    return 1
+  fi
+  printf '%s' "${sdk_archives[0]:-}"
+}
+
+sdk_archive="$(select_sdk_archive)"
+if [[ -z "${sdk_archive}" ]]; then
+  [[ "${mode}" == "download" ]]
+  artifact_name="sdk-${sdk_sha}"
+  run_id=""
+  mapfile -t candidates < <(gh api "repos/treeseed-ai/sdk/actions/artifacts?name=${artifact_name}&per_page=100" --jq ".artifacts[] | select(.expired == false and .workflow_run.head_sha == \"${sdk_sha}\") | .workflow_run.id")
+  for candidate in "${candidates[@]}"; do
+    state="$(gh run view "${candidate}" --repo treeseed-ai/sdk --json headSha,status,conclusion --jq '[.headSha,.status,.conclusion]|join(" ")')"
+    if [[ "${state}" == "${sdk_sha} completed success" ]]; then run_id="${candidate}"; break; fi
+  done
+  [[ -n "${run_id}" ]]
+  gh run download "${run_id}" --repo treeseed-ai/sdk --name "${artifact_name}" --dir "${archive_root}"
+  sdk_archive="$(select_sdk_archive)"
+fi
+
+[[ "${mode}" == "download" ]] && exit 0
+[[ "${mode}" == "install" && -n "${sdk_archive}" ]]
+target="node_modules/@treeseed/sdk"
+find "${target}" -mindepth 1 -maxdepth 1 ! -name node_modules -exec rm -rf -- {} +
+tar -xzf "${sdk_archive}" --strip-components=1 -C "${target}"
+test -d "${target}/dist"
+npm ls --all --omit=dev >/dev/null

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -24,12 +24,13 @@ test('the executable drains complete output before exiting', () => {
 	assert.equal(main.includes('process.exitCode = await runCommandLine'), true);
 });
 
-test('candidate promotion builds the exact SDK after lifecycle-disabled installation', () => {
+test('candidate promotion installs the sealed exact SDK after lifecycle-disabled installation', () => {
 	const workflow = readFileSync('.github/workflows/publish.yml', 'utf8');
+	const download = workflow.indexOf('hydrate-exact-sdk.sh candidate/sdk download');
 	const install = workflow.indexOf('npm ci --ignore-scripts --no-audit --no-fund');
-	const hydrate = workflow.indexOf('npm --prefix node_modules/@treeseed/sdk run build:dist');
+	const hydrate = workflow.indexOf('hydrate-exact-sdk.sh candidate/sdk install');
 	const verify = workflow.indexOf('npm run release:custody -- verify');
-	assert.ok(install >= 0 && hydrate > install && verify > hydrate);
+	assert.ok(download >= 0 && install > download && hydrate > install && verify > hydrate);
 });
 
 test('source contains no legacy implementation residue', () => {


### PR DESCRIPTION
## Outcome

Installs the sealed exact SDK Actions candidate during CLI promotion and prepares replacement rc51.

## Work authority

- Work item / Issue: #111
- Assignment: Hosted production release chain
- Actor: Codex under adrianwebb authority
- Exact base: staging at d9efca82d024b21c8231d7863d3ce5ec4e6ef45e
- Exact head: 6c7bbd4aa3a5844b79af57ed64be498d4bd0c947

## Changes

- Downloads only a successful, unexpired SDK Actions artifact bound to the exact SDK commit.
- Replaces only the installed SDK payload after lifecycle-disabled npm installation.
- Verifies the SDK distribution and dependency tree before CLI custody checks.
- Adds workflow ordering coverage and advances the replacement version to rc51.

## Verification

- Sealed SDK download and installation exercised locally against SDK staging bbc56dfdf5eb9a3ab4de642012256316b932782e.
- npm run verify:direct passes all 91 CLI tests and artifact packing.

## Risk and rollback

Candidate hydration is digest-bound by the SDK's protected Actions artifact and exact head SHA. Keep rc48 selected if protected rc51 publication or read-back fails.

## Completion summary

This replaces the incomplete rc50 source-build approach with immutable SDK artifact custody.

## Checklist

- [x] Exact refs recorded.
- [x] No global lifecycle scripts enabled.
- [x] SDK artifact requires a successful exact-head workflow.
- [x] Full CLI verification passes.
- [x] Failed rc49/rc50 candidates remain unselected.