### PR TITLE
Install CLI with the published SDK runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.51",
+  "version": "0.13.0-rc.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.51",
+      "version": "0.13.0-rc.52",
       "bundleDependencies": [
         "ink",
         "react",
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "github:treeseed-ai/sdk#bbc56dfdf5eb9a3ab4de642012256316b932782e",
+        "@treeseed/sdk": "0.13.0-rc.80",
         "ink": "^7.1.1",
         "react": "^19.2.8",
         "string-width": "^8.2.2",
@@ -493,9 +493,8 @@
     },
     "node_modules/@treeseed/sdk": {
       "version": "0.13.0-rc.80",
-      "resolved": "git+ssh://git@github.com/treeseed-ai/sdk.git#bbc56dfdf5eb9a3ab4de642012256316b932782e",
-      "integrity": "sha512-bOeNgI4b1U2S2gZnZjkFtRY8Y3In5tGDYc70MtkunOlZ3Nm7K6vG0eSNziHqsWdCMqWXZk3I1HPGKSsZHMl4Pg==",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.80.tgz",
+      "integrity": "sha512-eG+tt0FrjOPoxexPrHRvTNunBizoSpVmJDnTe6yZVMReozMB5VNib46S4AUz8n1/x67HhfyV2nPH9CJYVhSKLw==",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",
         "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.51",
+  "version": "0.13.0-rc.52",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -50,7 +50,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "github:treeseed-ai/sdk#bbc56dfdf5eb9a3ab4de642012256316b932782e",
+    "@treeseed/sdk": "0.13.0-rc.80",
     "ink": "^7.1.1",
     "react": "^19.2.8",
     "string-width": "^8.2.2",

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -9,7 +9,7 @@ test('package has one executable and only its declared CLI runtime dependencies'
 	assert.equal(pkg.types, undefined);
 	assert.equal(pkg.files.some((path: string) => path.startsWith('scripts/')), false);
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': 'github:treeseed-ai/sdk#bbc56dfdf5eb9a3ab4de642012256316b932782e', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.80', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
 });
 
 test('built package contains executable runtime only', () => {


### PR DESCRIPTION
Closes #114.

## Summary

- replace the CLI runtime's Git-source SDK dependency with exact `@treeseed/sdk@0.13.0-rc.80`
- resolve the registry tarball and immutable integrity in the lockfile
- advance the replacement candidate to `0.13.0-rc.52`
- update package-boundary coverage to require the published dependency

## Verification

- `npm run verify:direct`
- 91 tests pass
- packed CLI installed into an empty prefix with `--ignore-scripts`
- `trsd help platform` passes from that fresh install
- `git diff --check`

This fixes the `ERR_MODULE_NOT_FOUND` exposed by Platform run 33694792992 without enabling dependency lifecycle scripts.
