### PR TITLE
Promote CLI with the registry SDK dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,8 @@ jobs:
           run_id="$(gh run list --workflow verify.yml --branch staging --commit "$GITHUB_SHA" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
           test -n "$run_id"
           gh run download "$run_id" --name "cli-candidate-${GITHUB_SHA}" --dir candidate
-      - name: Download the sealed exact SDK candidate
-        run: ./scripts/build/hydrate-exact-sdk.sh candidate/sdk download
-        env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
-      - run: npm ci --ignore-scripts --no-audit --no-fund
-      - name: Install the sealed exact SDK candidate
-        run: ./scripts/build/hydrate-exact-sdk.sh candidate/sdk install
+      - name: Install exact published dependency graph
+        run: npm ci --ignore-scripts --no-audit --no-fund
       - run: npm run release:check-tag
       - run: npm run release:custody -- verify candidate/release-evidence-v1.json
       - name: Capture stable tag before publication

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.52",
+  "version": "0.13.0-rc.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.52",
+      "version": "0.13.0-rc.53",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.52",
+  "version": "0.13.0-rc.53",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -24,13 +24,12 @@ test('the executable drains complete output before exiting', () => {
 	assert.equal(main.includes('process.exitCode = await runCommandLine'), true);
 });
 
-test('candidate promotion installs the sealed exact SDK after lifecycle-disabled installation', () => {
+test('candidate promotion installs the exact registry SDK without lifecycle builds', () => {
 	const workflow = readFileSync('.github/workflows/publish.yml', 'utf8');
-	const download = workflow.indexOf('hydrate-exact-sdk.sh candidate/sdk download');
 	const install = workflow.indexOf('npm ci --ignore-scripts --no-audit --no-fund');
-	const hydrate = workflow.indexOf('hydrate-exact-sdk.sh candidate/sdk install');
 	const verify = workflow.indexOf('npm run release:custody -- verify');
-	assert.ok(download >= 0 && install > download && hydrate > install && verify > hydrate);
+	assert.equal(workflow.includes('hydrate-exact-sdk.sh'), false);
+	assert.ok(install >= 0 && verify > install);
 });
 
 test('source contains no legacy implementation residue', () => {


### PR DESCRIPTION
Closes #114.

## Summary

- remove the obsolete Git-commit SDK hydration steps from CLI promotion
- install the exact lockfile registry dependency graph with lifecycle scripts disabled
- retain custody verification after dependency installation
- publish replacement candidate `0.13.0-rc.53`; rc52 remains unpublished failed evidence

## Verification

- `npm run verify:direct`
- 91 tests and packed-install acceptance pass
- registry SDK tarball/integrity is locked
- `git diff --check`

This completes the package-side and promotion-side correction exposed by Platform run 33694792992 and rc52 run 33695186416.
