### PR TITLE
fix: authorize project creation plans idempotently

### DIFF
--- a/src/cli/commands/platform/index.ts
+++ b/src/cli/commands/platform/index.ts
@@ -66,10 +66,10 @@ async function projectCreate(invocation: ParsedInvocation, context: CommandConte
 	if (applying && invocation.options.yes !== true) throw Object.assign(new Error('Project creation apply requires --yes after reviewing the plan.'), { category: 'confirmation_required', code: 'confirmation_required' });
 	const template = templateLock(context.cwd, templateId);
 	let teamId = String(context.env.TREESEED_TEAM_ID ?? ''); let invoke: (body: Record<string, unknown>, apply: boolean) => Promise<unknown>;
-	if (context.operationInvoke) invoke = (body) => context.operationInvoke!('projects.create', { path: { teamId }, query: {}, body });
+	if (context.operationInvoke) invoke = (body) => context.operationInvoke!('projects.create', { path: { teamId }, query: {}, body }, { idempotencyKey: randomUUID() });
 	else {
 		const { client, session } = await createControlPlaneClient(invocation, context, true); teamId = String(session?.activeTeam?.id ?? '');
-		invoke = (body, apply) => client.invoke(CONTROL_PLANE_OPERATIONS.projects.create, { path: { teamId }, query: {}, body }, apply ? { idempotencyKey: randomUUID(), headers: {} } : undefined);
+		invoke = (body) => client.invoke(CONTROL_PLANE_OPERATIONS.projects.create, { path: { teamId }, query: {}, body }, { idempotencyKey: randomUUID(), headers: {} });
 	}
 	if (!teamId) throw Object.assign(new Error('Select an active team with `trsd teams use <team>` before creating a project.'), { category: 'ambiguous_context', code: 'active_team_required' });
 	const plan = projectCreatePlanSchema.parse(payload(await invoke({ mode: 'plan', target: { slug, template, repository: { name: slug, visibility: 'private' } } }, false)));

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -14,7 +14,7 @@ export interface CommandContext {
 	readStdin?: () => Promise<string> | string;
 	confirm?: (question: string, defaultValue?: 'yes' | 'no') => Promise<boolean> | boolean;
 	openExternal?: (url: string) => Promise<boolean> | boolean;
-	operationInvoke?: (operationId: string, input: unknown) => Promise<unknown>;
+	operationInvoke?: (operationId: string, input: unknown, options?: { idempotencyKey?: string; headers?: Record<string, string> }) => Promise<unknown>;
 	hostInvoke?: (input: { handlerId: string; arguments: string[]; options: Record<string, string | string[] | boolean | undefined> }) => Promise<unknown>;
 	providerEnrollmentHandoff?: (input: Record<string, unknown>) => Promise<Record<string, unknown>>;
 }

--- a/tests/unit/command-boundary/platform/project-create.test.ts
+++ b/tests/unit/command-boundary/platform/project-create.test.ts
@@ -22,9 +22,10 @@ test('platform project create plans through API authority without mutation', asy
 	try {
 		const exit = await runCommandLine(['platform', 'project', 'create', 'example-app', '--template', 'engineering', '--plan', '--json'], {
 			cwd: root, env: { TREESEED_TEAM_ID: 'team-1' }, interactiveUi: false, write: (value) => output.push(value),
-			operationInvoke: async (operationId, input) => { calls.push({ operationId, input }); return { data: plan }; },
+			operationInvoke: async (operationId, input, options) => { calls.push({ operationId, input, options }); return { data: plan }; },
 		});
 		assert.equal(exit, 0, output.join('\n')); assert.equal(calls.length, 1); assert.equal(calls[0].input.body.mode, 'plan');
+		assert.match(calls[0].options.idempotencyKey, /^[0-9a-f-]{36}$/u);
 		assert.equal(JSON.parse(output[0]!).result.planDigest, digest);
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
@@ -34,9 +35,11 @@ test('platform project create applies the exact API plan and never writes applic
 	try {
 		const exit = await runCommandLine(['platform', 'project', 'create', 'example-app', '--template', 'engineering', '--apply', '--yes', '--json'], {
 			cwd: root, env: { TREESEED_TEAM_ID: 'team-1' }, interactiveUi: false, write: (value) => output.push(value),
-			operationInvoke: async (operationId, input: any) => { calls.push({ operationId, input }); return input.body.mode === 'plan' ? { data: plan } : { data: { ...plan, schemaVersion: 'treeseed.platform-project-create-receipt/v1', projectId: 'project-1' } }; },
+			operationInvoke: async (operationId, input: any, options) => { calls.push({ operationId, input, options }); return input.body.mode === 'plan' ? { data: plan } : { data: { ...plan, schemaVersion: 'treeseed.platform-project-create-receipt/v1', projectId: 'project-1' } }; },
 		});
 		assert.equal(exit, 0, output.join('\n')); assert.deepEqual(calls.map((call) => call.input.body.mode), ['plan', 'apply']);
+		assert.equal(calls.every((call) => /^[0-9a-f-]{36}$/u.test(call.options.idempotencyKey)), true);
+		assert.notEqual(calls[0].options.idempotencyKey, calls[1].options.idempotencyKey);
 		assert.equal(calls[1].input.body.plan.planDigest, digest); assert.equal(JSON.parse(output[0]!).result.projectId, 'project-1');
 		assert.equal(await import('node:fs').then(({ existsSync }) => existsSync(resolve(root, 'packages/example-app'))), false);
 	} finally { rmSync(root, { recursive: true, force: true }); }


### PR DESCRIPTION
Closes #117.

Authenticated project-creation planning now sends a bounded generated Idempotency-Key, matching the control-plane POST contract. Apply continues to receive an independent key. The test seam carries the same invocation metadata so unit coverage exercises the real boundary.

Verification:
- focused project-create tests: 2/2
- `npm run verify:direct`