### PR TITLE
chore(release): prepare CLI 0.13.0-rc.54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.53",
+  "version": "0.13.0-rc.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.53",
+      "version": "0.13.0-rc.54",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.53",
+  "version": "0.13.0-rc.54",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Completes the release portion of #117.

Bumps the verified project-create idempotency fix to `0.13.0-rc.54` so protected staging can seal and publish an immutable candidate.

Verification: `npm run verify:direct`.