### PR TITLE
Authorize hosted topology from the client-encrypted vault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.82",
+        "@treeseed/sdk": "0.13.0-rc.84",
         "ink": "^7.1.1",
         "react": "^19.2.8",
         "string-width": "^8.2.2",
@@ -1306,9 +1306,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1327,9 +1324,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1348,9 +1342,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1369,9 +1360,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1390,9 +1378,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1411,9 +1396,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1432,9 +1414,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1453,9 +1432,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1474,9 +1450,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1501,9 +1474,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1528,9 +1498,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1555,9 +1522,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1582,9 +1546,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1609,9 +1570,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1636,9 +1594,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1663,9 +1618,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2578,9 +2530,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3578,9 +3527,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3596,9 +3542,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3614,9 +3557,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3632,9 +3572,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3650,9 +3587,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3668,9 +3602,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3686,9 +3617,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3704,9 +3632,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3722,9 +3647,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3740,9 +3662,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3758,9 +3677,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3776,9 +3692,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3794,9 +3707,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4027,13 +3937,13 @@
       "peer": true
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.82",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.82.tgz",
-      "integrity": "sha512-3dkc0jUlxwc5kSlew8MlmlgDxwv4AMfPjXJR6PsexKedEH8s65y0u9TxD9SASd/titmrIX/Nqczk0t/RSq2BmA==",
-      "license": "Apache-2.0",
+      "version": "0.13.0-rc.84",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.84.tgz",
+      "integrity": "sha512-U/AXCUxEudtyS53caSeGHWFirrWfNe8gFgu7tiFh/3KHtcbND2H72Gs+2AQWhJYKnk2Wi9tNk6gZov4Xjk/oTw==",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",
         "esbuild": "^0.28.0",
+        "libsodium-wrappers-sumo": "0.8.4",
         "typescript": "^5.9.3",
         "yaml": "^2.8.1",
         "zod": "^3.25.76"
@@ -7205,6 +7115,19 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/libsodium-sumo": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.8.4.tgz",
+      "integrity": "sha512-TMtHShQfVVsaxDygyapvUC3o7YsPgXa/hRWeIgzyFz6w5k/1hirGptCxp1U7XwW3rCskaTTYKgV10v86UiGgNw=="
+    },
+    "node_modules/libsodium-wrappers-sumo": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.8.4.tgz",
+      "integrity": "sha512-ql7hcgulKZ3ekfa2DGAogcCKsWU0diA/0nArz1CFzh93WQdb46/Kj18ka/Hifq6uA3Ush34Pc6vU/6HXeRwUkg==",
+      "dependencies": {
+        "libsodium-sumo": "^0.8.0"
       }
     },
     "node_modules/longest-streak": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.82",
+    "@treeseed/sdk": "0.13.0-rc.84",
     "ink": "^7.1.1",
     "react": "^19.2.8",
     "string-width": "^8.2.2",

--- a/src/cli/commands/platform/hosted-vault.ts
+++ b/src/cli/commands/platform/hosted-vault.ts
@@ -1,0 +1,105 @@
+import {
+	SERVICE_VAULT_ENCRYPTION_VERSION,
+	canonicalServiceVaultAssociatedData,
+	clearServiceVaultKey,
+	decryptServiceCredential,
+	decryptServiceVaultPrivateKey,
+	openTeamVaultGrant,
+	sealSecretOperationPayload,
+} from '@treeseed/sdk/secrets-capability';
+import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
+import type { CommandContext } from '../../types.js';
+import { promptHidden } from '../../support/prompts.js';
+
+type Invoke = (operation: any, input: unknown, mutation?: boolean) => Promise<unknown>;
+const value = (response: unknown) => response && typeof response === 'object' && !Array.isArray(response) && 'data' in response
+	? (response as { data: unknown }).data : response;
+const pause = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function waitForLease(teamId: string, lease: any, invoke: Invoke) {
+	const operation = CONTROL_PLANE_OPERATIONS.services.operationLease;
+	for (let attempt = 0; attempt < 240; attempt += 1) {
+		const current: any = value(await invoke(operation, { path: { teamId, leaseId: lease.id }, query: {}, body: undefined }));
+		if (current?.publicKey && current.status === 'pending') return current;
+		if (['cancelled', 'consumed', 'expired', 'failed'].includes(String(current?.status)))
+			throw new Error(`Hosted credential lease ${lease.id} ended before authorization.`);
+		await pause(500);
+	}
+	throw new Error(`Hosted credential lease ${lease.id} did not receive an ephemeral runner key.`);
+}
+
+async function authorizeLeases(leases: any[], teamId: string, invoke: Invoke, context: CommandContext) {
+	if (!leases.length) return;
+	if (context.outputFormat === 'human') for (const lease of leases) {
+		const binding = lease.hostedBinding ?? {};
+		context.write(`Authorize hosted credentials\nTeam: ${teamId}\nEnvironment: ${binding.environment ?? 'unknown'}\nSubject: ${binding.subjectDigest ?? 'unknown'}\nPurpose: ${lease.purpose}\nFields: ${(lease.requiredFields ?? []).join(', ')}\nExpires: ${lease.expiresAt}\n`, 'stderr');
+	}
+	const operations = CONTROL_PLANE_OPERATIONS.services;
+	const userKey: any = value(await invoke(operations.userVaultKey, { path: {}, query: {}, body: undefined }));
+	const vault: any = value(await invoke(operations.teamVault, { path: { teamId }, query: {}, body: undefined }));
+	if (!userKey?.encryptedPrivateKeyEnvelope || !vault?.ownGrant)
+		throw new Error('The current user needs an active personal key and team-vault grant before authorizing hosted credentials.');
+	if (!context.interactiveUi && !context.promptSecret && !context.readStdin)
+		throw new Error('Headless hosted client-vault authorization requires the passphrase on standard input.');
+	const passphrase = context.promptSecret
+		? String(await context.promptSecret('Personal service-vault passphrase: '))
+		: context.readStdin ? String(await context.readStdin()).trim() : await promptHidden('Personal service-vault passphrase: ');
+	const privateKey = await decryptServiceVaultPrivateKey(userKey.encryptedPrivateKeyEnvelope, passphrase);
+	const teamKey = await openTeamVaultGrant({ version: SERVICE_VAULT_ENCRYPTION_VERSION, algorithm: 'x25519-sealed-box',
+		recipientPublicKey: userKey.encryptedPrivateKeyEnvelope.publicKey,
+		wrappedTeamVaultKey: vault.ownGrant.wrappedTeamVaultKey }, privateKey);
+	const envelopeCache = new Map<string, any[]>();
+	try {
+		for (const lease of leases) {
+			const current = await waitForLease(teamId, lease, invoke);
+			let envelopes = envelopeCache.get(current.connectionId);
+			if (!envelopes) {
+				envelopes = value(await invoke(operations.credentialEnvelopes, {
+					path: { teamId, connectionId: current.connectionId }, query: {}, body: undefined,
+				})) as any[];
+				envelopeCache.set(current.connectionId, envelopes);
+			}
+			const selected = envelopes.filter((item) => item.definitionId === current.credentialProfileId
+				&& current.requiredFields.includes(item.fieldKey));
+			if (selected.length !== current.requiredFields.length
+				|| new Set(selected.map((item) => item.fieldKey)).size !== current.requiredFields.length)
+				throw new Error(`Hosted credential profile ${current.credentialProfileId} is incomplete.`);
+			let values: Record<string, string> = {};
+			try {
+				values = Object.fromEntries(await Promise.all(selected.map(async (item) => [item.fieldKey,
+					await decryptServiceCredential(item.envelope, teamKey, canonicalServiceVaultAssociatedData({
+						teamId, connectionId: current.connectionId, credentialProfileId: current.credentialProfileId,
+						field: item.fieldKey, purpose: 'team-service-credential', version: item.keyVersion,
+					})),
+				])));
+				const sealedPayload = await sealSecretOperationPayload(values, current.publicKey);
+				await invoke(operations.putOperationLeasePayload, { path: { teamId, leaseId: current.id }, query: {},
+					body: { sealedPayload } }, true);
+			} finally { values = {}; }
+		}
+	} finally {
+		clearServiceVaultKey(teamKey);
+		clearServiceVaultKey(privateKey);
+	}
+}
+
+async function waitForOperation(operationId: string, invoke: Invoke) {
+	const operation = CONTROL_PLANE_OPERATIONS.operations.show;
+	for (let attempt = 0; attempt < 600; attempt += 1) {
+		const current: any = value(await invoke(operation, { path: { operationId }, query: {}, body: undefined }));
+		if (current?.status === 'completed') return current.output;
+		if (['cancelled', 'failed'].includes(String(current?.status)))
+			throw Object.assign(new Error(current?.error?.message ?? `Hosted topology operation ${operationId} failed.`),
+				{ category: 'operation_failed', code: current?.error?.code ?? 'hosted_topology_operation_failed' });
+		await pause(500);
+	}
+	throw new Error(`Hosted topology operation ${operationId} did not complete within five minutes.`);
+}
+
+export async function completeHostedTopologyOperation(response: unknown, teamId: string, invoke: Invoke, context: CommandContext) {
+	const accepted: any = value(response);
+	if (!accepted?.operation?.id) return accepted;
+	await authorizeLeases(Array.isArray(accepted.credentialLeases) ? accepted.credentialLeases : [], teamId, invoke, context);
+	const output: any = await waitForOperation(accepted.operation.id, invoke);
+	return output?.plan ?? output?.receipt ?? output;
+}

--- a/src/cli/commands/platform/index.ts
+++ b/src/cli/commands/platform/index.ts
@@ -5,9 +5,10 @@ import { relative, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { applyPlatformWorkset, loadPlatformInventory, loadPlatformProfiles, planPlatformWorkset, projectCreatePlanSchema, resolveProfileProjects, verifyPlatformRepository } from '@treeseed/sdk/platform';
 import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
-import { compileHostedTopologyTemplate, hostedTopologyApprovalSchema, hostedTopologyArtifactInputsSchema, hostedTopologyDeclarationSchema, hostedTopologyPlanSchema, hostedTopologyRollbackApprovalSchema, hostedTopologyRollbackSchema, hostedTopologyTemplateSchema } from '@treeseed/sdk/deployment';
+import { compileHostedTopologyTemplate, hostedTopologyApprovalSchema, hostedTopologyArtifactInputsSchema, hostedTopologyDeclarationSchema, hostedTopologyPlanSchema, hostedTopologyRollbackExecutionApprovalSchema, hostedTopologyRollbackExecutionSchema, hostedTopologyTemplateSchema } from '@treeseed/sdk/deployment';
 import type { CommandContext, ParsedInvocation } from '../../types.js';
 import { createControlPlaneClient } from '../../support/client.js';
+import { completeHostedTopologyOperation } from './hosted-vault.js';
 
 const values = (value: string | string[] | boolean | undefined) => Array.isArray(value) ? value : typeof value === 'string' ? [value] : [];
 const invalid = (code: string, message: string) => Object.assign(new Error(message), { category: 'invalid_input', code });
@@ -117,7 +118,7 @@ async function topology(invocation: ParsedInvocation, context: CommandContext) {
 			declaration = hostedTopologyDeclarationSchema.parse(source);
 		}
 		if (declaration.teamId !== teamId) throw invalid('topology_team_mismatch', 'The hosted topology declaration is not bound to the active team.');
-		return payload(await invoke(operations.plan, { path: { teamId }, query: {}, body: { declaration } }));
+		return completeHostedTopologyOperation(await invoke(operations.plan, { path: { teamId }, query: {}, body: { declaration } }), teamId, invoke, context);
 	}
 	if (invocation.command.name === 'platform topology status') return payload(await invoke(operations.status, { path: { teamId }, query: {}, body: undefined }));
 	if (invocation.options.yes !== true) throw Object.assign(new Error('Hosted topology mutation requires --yes after reviewing the exact plan and approval.'), { category: 'confirmation_required', code: 'confirmation_required' });
@@ -127,12 +128,17 @@ async function topology(invocation: ParsedInvocation, context: CommandContext) {
 		const plan = hostedTopologyPlanSchema.parse(document(invocation.arguments[0]!, context));
 		const approval = hostedTopologyApprovalSchema.parse(document(approvalPath, context));
 		if (plan.teamId !== teamId || approval.teamId !== teamId) throw invalid('topology_team_mismatch', 'The hosted topology plan and approval must be bound to the active team.');
-		return payload(await invoke(operations.apply, { path: { teamId }, query: {}, body: { plan, approval } }, true));
+		return completeHostedTopologyOperation(await invoke(operations.apply, { path: { teamId }, query: {}, body: { plan, approval } }, true), teamId, invoke, context);
 	}
-	const rollback = hostedTopologyRollbackSchema.parse(document(invocation.arguments[0]!, context));
-	const approval = hostedTopologyRollbackApprovalSchema.parse(document(approvalPath, context));
-	if (rollback.teamId !== teamId || approval.teamId !== teamId) throw invalid('topology_team_mismatch', 'The hosted topology rollback and approval must be bound to the active team.');
-	return payload(await invoke(operations.rollback, { path: { teamId }, query: {}, body: { rollback, approval } }, true));
+	const rollbackBundle = document(invocation.arguments[0]!, context) as Record<string, unknown>;
+	const execution = hostedTopologyRollbackExecutionSchema.parse(rollbackBundle.execution);
+	const sourcePlan = hostedTopologyPlanSchema.parse(rollbackBundle.sourcePlan);
+	const targetPlan = hostedTopologyPlanSchema.parse(rollbackBundle.targetPlan);
+	const approval = hostedTopologyRollbackExecutionApprovalSchema.parse(document(approvalPath, context));
+	if (execution.teamId !== teamId || sourcePlan.teamId !== teamId || targetPlan.teamId !== teamId || approval.teamId !== teamId)
+		throw invalid('topology_team_mismatch', 'The hosted topology rollback closure and approval must be bound to the active team.');
+	return completeHostedTopologyOperation(await invoke(operations.rollback, { path: { teamId }, query: {},
+		body: { execution, approval, sourcePlan, targetPlan } }, true), teamId, invoke, context);
 }
 
 export function runPlatform(invocation: ParsedInvocation, context: CommandContext) {

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -13,7 +13,7 @@ import { runDevelopment } from './commands/development.js';
 import { runInbox } from './commands/inbox.js';
 import { runPlatform } from './commands/platform/index.js';
 import type { CommandContext, CommandFailure, ParsedInvocation, Writer } from './types.js';
-import { promptText } from './support/prompts.js';
+import { promptText, readStandardInput } from './support/prompts.js';
 import { handoffProviderEnrollment } from './support/provider-enrollment.js';
 import { renderHumanCommandResult } from './support/human-renderer.js';
 import { openBrowser } from './support/open-browser.js';
@@ -26,7 +26,9 @@ function defaultWrite(output: string, stream: 'stdout' | 'stderr' = 'stdout') {
 
 export function createCommandContext(overrides: Partial<CommandContext> = {}): CommandContext {
 	const env = overrides.env ?? process.env;
-	const context: CommandContext = { cwd: overrides.cwd ?? process.cwd(), env, write: overrides.write ?? defaultWrite as Writer, outputFormat: overrides.outputFormat ?? 'human', interactiveUi: overrides.interactiveUi ?? true, prompt: overrides.prompt, promptSecret: overrides.promptSecret, readStdin: overrides.readStdin, confirm: overrides.confirm, openExternal: overrides.openExternal ?? openBrowser, operationInvoke: overrides.operationInvoke, hostInvoke: overrides.hostInvoke,
+	const context: CommandContext = { cwd: overrides.cwd ?? process.cwd(), env, write: overrides.write ?? defaultWrite as Writer, outputFormat: overrides.outputFormat ?? 'human', interactiveUi: overrides.interactiveUi ?? true, prompt: overrides.prompt, promptSecret: overrides.promptSecret,
+		readStdin: overrides.readStdin ?? (process.stdin.isTTY ? undefined : readStandardInput), confirm: overrides.confirm,
+		openExternal: overrides.openExternal ?? openBrowser, operationInvoke: overrides.operationInvoke, hostInvoke: overrides.hostInvoke,
 		providerEnrollmentHandoff: overrides.providerEnrollmentHandoff ?? ((input) => handoffProviderEnrollment(input, env)) };
 	if (!context.confirm && context.interactiveUi) context.confirm = async (question) => /^y(?:es)?$/iu.test(await promptText(context, `${question} [y/N] `));
 	return context;

--- a/src/cli/support/prompts.ts
+++ b/src/cli/support/prompts.ts
@@ -9,6 +9,12 @@ export async function promptText(context: CommandContext, question: string) {
 	try { return (await prompt.question(question)).trim(); } finally { prompt.close(); }
 }
 
+export async function readStandardInput() {
+	let value = '';
+	for await (const chunk of stdin) value += String(chunk);
+	return value;
+}
+
 export function promptHidden(question: string) {
 	return new Promise<string>((resolvePromise, reject) => {
 		if (!stdin.isTTY || !stdout.isTTY) { reject(new Error('Secret input requires an interactive TTY.')); return; }

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -9,7 +9,7 @@ test('package has one executable and only its declared CLI runtime dependencies'
 	assert.equal(pkg.types, undefined);
 	assert.equal(pkg.files.some((path: string) => path.startsWith('scripts/')), false);
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.82', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.84', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
 	assert.equal(pkg.devDependencies['@treeseed/ui'], '>=0.12.18-rc.12 <0.14.0');
 });
 

--- a/tests/unit/command-boundary/platform/hosted-vault.test.ts
+++ b/tests/unit/command-boundary/platform/hosted-vault.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	SERVICE_VAULT_ENCRYPTION_VERSION, canonicalServiceVaultAssociatedData, clearServiceVaultKey,
+	createServiceVaultKey, createServiceVaultUserKeyPair, createTeamVaultGrant, encryptServiceCredential,
+	encryptServiceVaultPrivateKey, openSecretOperationPayload,
+} from '@treeseed/sdk/secrets-capability';
+import { completeHostedTopologyOperation } from '../../../../src/cli/commands/platform/hosted-vault.ts';
+
+test('hosted topology authorization decrypts in process and sends only a sealed one-use payload', async () => {
+	const teamId = 'team-1', connectionId = 'railway-staging', passphrase = 'correct horse battery staple';
+	const userPair = await createServiceVaultUserKeyPair(), operationPair = await createServiceVaultUserKeyPair();
+	const teamKey = await createServiceVaultKey();
+	try {
+		const privateEnvelope = await encryptServiceVaultPrivateKey(userPair.privateKey, userPair.publicKey, passphrase, { opsLimit: 2, memLimit: 67_108_864 });
+		const grant = await createTeamVaultGrant(teamKey, userPair.publicKey), keyVersion = 1;
+		const associatedData = canonicalServiceVaultAssociatedData({ teamId, connectionId,
+			credentialProfileId: 'railway-workspace', field: 'apiToken', purpose: 'team-service-credential', version: keyVersion });
+		const envelope = await encryptServiceCredential('railway-secret', teamKey, associatedData);
+		let sealedPayload = '';
+		const invoke = async (operation: any, input: any) => {
+			const id = operation.descriptor.operationId;
+			if (id === 'services.vault.user.key.show') return { data: { encryptedPrivateKeyEnvelope: privateEnvelope } };
+			if (id === 'services.vault.team.show') return { data: { ownGrant: { wrappedTeamVaultKey: grant.wrappedTeamVaultKey } } };
+			if (id === 'services.operation.leases.show') return { data: { id: 'lease-1', teamId, connectionId,
+				credentialProfileId: 'railway-workspace', requiredFields: ['apiToken'], publicKey: operationPair.publicKey, status: 'pending' } };
+			if (id === 'services.credential.envelopes.list') return { data: [{ definitionId: 'railway-workspace',
+				credentialProfileId: 'profile-row-1', fieldKey: 'apiToken', keyVersion, envelope }] };
+			if (id === 'services.operation.leases.payload.put') { sealedPayload = input.body.sealedPayload; return { data: { status: 'ready' } }; }
+			if (id === 'operations.show') return { data: { status: 'completed', output: { plan: { planDigest: `sha256:${'a'.repeat(64)}` } } } };
+			throw new Error(`Unexpected operation ${id}`);
+		};
+		const result = await completeHostedTopologyOperation({ operation: { id: 'operation-1' }, credentialLeases: [{ id: 'lease-1' }] },
+			teamId, invoke, { cwd: '.', env: {}, write() {}, outputFormat: 'json', interactiveUi: false,
+				readStdin: async () => `${passphrase}\n` });
+		assert.deepEqual(result, { planDigest: `sha256:${'a'.repeat(64)}` });
+		assert.deepEqual(await openSecretOperationPayload(sealedPayload, operationPair.publicKey, operationPair.privateKey),
+			{ apiToken: 'railway-secret' });
+		assert.equal(JSON.stringify(result).includes('railway-secret'), false);
+	} finally {
+		clearServiceVaultKey(teamKey);
+		clearServiceVaultKey(userPair.privateKey);
+		clearServiceVaultKey(operationPair.privateKey);
+	}
+});

--- a/tests/unit/command-boundary/platform/topology.test.ts
+++ b/tests/unit/command-boundary/platform/topology.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import test from 'node:test';
-import { authorizeHostedTopologyPlan, bindHostedStateBackend, hostedTopologyStateKey, planHostedTopology, planHostedTopologyRollback, verifyHostedTopologyReadback } from '@treeseed/sdk/deployment';
+import { authorizeHostedTopologyPlan, bindHostedStateBackend, hostedTopologyStateKey, planHostedTopology, planHostedTopologyRollback, planHostedTopologyRollbackExecution, verifyHostedTopologyReadback } from '@treeseed/sdk/deployment';
 import { runCommandLine } from '../../../../src/cli/runtime.ts';
 
 const teamId = 'team-treeseed';
@@ -17,17 +17,22 @@ const backend = bindHostedStateBackend({ schemaVersion: 'treeseed.hosted-state-b
 	connectionRef: 'cloudflare-state', bucket: 'treeseed-state', key: hostedTopologyStateKey(declaration), region: 'auto', endpoint: 'https://example.r2.cloudflarestorage.com', usePathStyle: true, encryptionKeyRef: 'state-key' });
 const plan = planHostedTopology({ declaration, observations: [], connections: {}, stateBackend: backend });
 const planApproval = { schemaVersion: 'treeseed.hosted-topology-approval/v1' as const, planDigest: plan.planDigest, teamId, deploymentId: plan.deploymentId, stackId: plan.stackId, environment: plan.environment, backendBindingDigest: backend.bindingDigest, decision: 'approved' as const, approvedBy: 'owner', approvedAt: now };
-const sourcePlan = authorizeHostedTopologyPlan(plan);
-const receipt = verifyHostedTopologyReadback({ plan: sourcePlan, previousResources: [], resources: [], completedAt: now });
+const authorizedPlan = authorizeHostedTopologyPlan(plan);
+const receipt = verifyHostedTopologyReadback({ plan: authorizedPlan, previousResources: [], resources: [], completedAt: now });
 const rollback = planHostedTopologyRollback(receipt);
-const rollbackApproval = { schemaVersion: 'treeseed.hosted-topology-rollback-approval/v1' as const, rollbackDigest: rollback.rollbackDigest, teamId, deploymentId: rollback.deploymentId, stackId: rollback.stackId, environment: rollback.environment, backendBindingDigest: rollback.backendBindingDigest, decision: 'approved' as const, approvedBy: 'owner', approvedAt: now };
+const targetPlan = planHostedTopology({ declaration, observations: [], connections: {}, stateBackend: backend });
+const execution = planHostedTopologyRollbackExecution({ rollback, sourceReceipt: receipt, sourcePlan: plan, targetPlan });
+const rollbackApproval = { schemaVersion: 'treeseed.hosted-topology-rollback-execution-approval/v1' as const,
+	executionDigest: execution.executionDigest, teamId, deploymentId: execution.deploymentId, stackId: execution.stackId,
+	environment: execution.environment, backendBindingDigest: execution.backendBindingDigest, decision: 'approved' as const,
+	approvedBy: 'owner', approvedAt: now };
 
 function fixture() {
 	const root = mkdtempSync(resolve(tmpdir(), 'platform-topology-cli-'));
 	writeFileSync(resolve(root, 'topology.yaml'), JSON.stringify(declaration));
 	writeFileSync(resolve(root, 'plan.json'), JSON.stringify(plan));
 	writeFileSync(resolve(root, 'plan-approval.json'), JSON.stringify(planApproval));
-	writeFileSync(resolve(root, 'rollback.json'), JSON.stringify(rollback));
+	writeFileSync(resolve(root, 'rollback.json'), JSON.stringify({ execution, sourcePlan: plan, targetPlan }));
 	writeFileSync(resolve(root, 'rollback-approval.json'), JSON.stringify(rollbackApproval));
 	return root;
 }


### PR DESCRIPTION
Closes #121

Topology plan, apply, and rollback now wait for their managed operation, authorize exact short-lived leases from browser-compatible client custody, and return only redacted plans or receipts. Interactive prompts and standard input are supported; no credential argument or environment path exists.