### PR TITLE
Remove hosted topology approval-file UX

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -323,7 +323,7 @@ Execution: `local.platform.topology.plan`.
 
 ### trsd platform topology apply <plan>
 
-Apply an exact reviewed hosted-topology plan through the operations runner.
+Apply an exact agent-authorized hosted-topology plan through the operations runner.
 
 Operation: mutation. Result schema: `treeseed.platform-operation/v1`.
 Execution: `local.platform.topology.apply`.
@@ -331,7 +331,6 @@ Execution: `local.platform.topology.apply`.
 - `--yes`: Confirm authorized automation.
 - `--json`: Emit the stable JSON envelope.
 - `--plan`: Return the exact proposed outcome without mutation.
-- `--approval <value>`: Exact environment approval JSON file.
 
 ### trsd platform topology status
 
@@ -352,7 +351,6 @@ Execution: `local.platform.topology.rollback`.
 - `--yes`: Confirm authorized automation.
 - `--json`: Emit the stable JSON envelope.
 - `--plan`: Return the exact proposed outcome without mutation.
-- `--approval <value>`: Exact rollback approval JSON file.
 
 ## trsd dev
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.56",
+  "version": "0.13.0-rc.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.56",
+      "version": "0.13.0-rc.57",
       "bundleDependencies": [
         "ink",
         "react",
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.85",
+        "@treeseed/sdk": "0.13.0-rc.86",
         "ink": "^7.1.1",
         "react": "^19.2.8",
         "string-width": "^8.2.2",
@@ -3937,9 +3937,9 @@
       "peer": true
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.85",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.85.tgz",
-      "integrity": "sha512-TgxdFRvUr0P0hYh+4UrT1DbRfctnuldmAEd6BEH/mdpImDV1PhTQKX+x50u8P5ZKGmZAArvCSQabK5Nt60nN6Q==",
+      "version": "0.13.0-rc.86",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.86.tgz",
+      "integrity": "sha512-Lc1JpqY7/GyfaqY/UEJoYto/H6zQGEj5g4pjeLrC11f/gFzMHq/wty4oiVsv/7BsuGlxJJ+EFtSzIdyyLuPLHA==",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",
         "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.56",
+  "version": "0.13.0-rc.57",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -51,7 +51,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.85",
+    "@treeseed/sdk": "0.13.0-rc.86",
     "ink": "^7.1.1",
     "react": "^19.2.8",
     "string-width": "^8.2.2",

--- a/schemas/command-tree.json
+++ b/schemas/command-tree.json
@@ -969,7 +969,7 @@
             {
               "nodeType": "leaf",
               "segment": "apply",
-              "description": "Apply an exact reviewed hosted-topology plan through the operations runner.",
+              "description": "Apply an exact agent-authorized hosted-topology plan through the operations runner.",
               "kind": "mutation",
               "arguments": [
                 {
@@ -983,12 +983,6 @@
                   "name": "--plan",
                   "description": "Return the exact proposed outcome without mutation.",
                   "type": "boolean"
-                },
-                {
-                  "name": "--approval",
-                  "description": "Exact environment approval JSON file.",
-                  "type": "string",
-                  "required": true
                 },
                 {
                   "name": "--yes",
@@ -1034,12 +1028,6 @@
                   "name": "--plan",
                   "description": "Return the exact proposed outcome without mutation.",
                   "type": "boolean"
-                },
-                {
-                  "name": "--approval",
-                  "description": "Exact rollback approval JSON file.",
-                  "type": "string",
-                  "required": true
                 },
                 {
                   "name": "--yes",

--- a/src/cli/commands/platform/index.ts
+++ b/src/cli/commands/platform/index.ts
@@ -5,7 +5,7 @@ import { relative, resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { applyPlatformWorkset, loadPlatformInventory, loadPlatformProfiles, planPlatformWorkset, projectCreatePlanSchema, resolveProfileProjects, verifyPlatformRepository } from '@treeseed/sdk/platform';
 import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
-import { compileHostedTopologyTemplate, hostedTopologyApprovalSchema, hostedTopologyArtifactInputsSchema, hostedTopologyDeclarationSchema, hostedTopologyPlanSchema, hostedTopologyRollbackExecutionApprovalSchema, hostedTopologyRollbackExecutionSchema, hostedTopologyTemplateSchema } from '@treeseed/sdk/deployment';
+import { compileHostedTopologyTemplate, hostedTopologyArtifactInputsSchema, hostedTopologyDeclarationSchema, hostedTopologyPlanSchema, hostedTopologyRollbackExecutionSchema, hostedTopologyTemplateSchema } from '@treeseed/sdk/deployment';
 import type { CommandContext, ParsedInvocation } from '../../types.js';
 import { createControlPlaneClient } from '../../support/client.js';
 import { completeHostedTopologyOperation } from './hosted-vault.js';
@@ -121,24 +121,20 @@ async function topology(invocation: ParsedInvocation, context: CommandContext) {
 		return completeHostedTopologyOperation(await invoke(operations.plan, { path: { teamId }, query: {}, body: { declaration } }), teamId, invoke, context);
 	}
 	if (invocation.command.name === 'platform topology status') return payload(await invoke(operations.status, { path: { teamId }, query: {}, body: undefined }));
-	if (invocation.options.yes !== true) throw Object.assign(new Error('Hosted topology mutation requires --yes after reviewing the exact plan and approval.'), { category: 'confirmation_required', code: 'confirmation_required' });
-	const approvalPath = String(invocation.options.approval ?? '');
-	if (!approvalPath) throw invalid('topology_approval_required', '--approval is required.');
+	if (invocation.options.yes !== true) throw Object.assign(new Error('Hosted topology mutation requires --yes after reviewing the exact plan.'), { category: 'confirmation_required', code: 'confirmation_required' });
 	if (invocation.command.name === 'platform topology apply') {
 		const plan = hostedTopologyPlanSchema.parse(document(invocation.arguments[0]!, context));
-		const approval = hostedTopologyApprovalSchema.parse(document(approvalPath, context));
-		if (plan.teamId !== teamId || approval.teamId !== teamId) throw invalid('topology_team_mismatch', 'The hosted topology plan and approval must be bound to the active team.');
-		return completeHostedTopologyOperation(await invoke(operations.apply, { path: { teamId }, query: {}, body: { plan, approval } }, true), teamId, invoke, context);
+		if (plan.teamId !== teamId) throw invalid('topology_team_mismatch', 'The hosted topology plan must be bound to the active team.');
+		return completeHostedTopologyOperation(await invoke(operations.apply, { path: { teamId }, query: {}, body: { plan } }, true), teamId, invoke, context);
 	}
 	const rollbackBundle = document(invocation.arguments[0]!, context) as Record<string, unknown>;
 	const execution = hostedTopologyRollbackExecutionSchema.parse(rollbackBundle.execution);
 	const sourcePlan = hostedTopologyPlanSchema.parse(rollbackBundle.sourcePlan);
 	const targetPlan = hostedTopologyPlanSchema.parse(rollbackBundle.targetPlan);
-	const approval = hostedTopologyRollbackExecutionApprovalSchema.parse(document(approvalPath, context));
-	if (execution.teamId !== teamId || sourcePlan.teamId !== teamId || targetPlan.teamId !== teamId || approval.teamId !== teamId)
-		throw invalid('topology_team_mismatch', 'The hosted topology rollback closure and approval must be bound to the active team.');
+	if (execution.teamId !== teamId || sourcePlan.teamId !== teamId || targetPlan.teamId !== teamId)
+		throw invalid('topology_team_mismatch', 'The hosted topology rollback closure must be bound to the active team.');
 	return completeHostedTopologyOperation(await invoke(operations.rollback, { path: { teamId }, query: {},
-		body: { execution, approval, sourcePlan, targetPlan } }, true), teamId, invoke, context);
+		body: { execution, sourcePlan, targetPlan } }, true), teamId, invoke, context);
 }
 
 export function runPlatform(invocation: ParsedInvocation, context: CommandContext) {

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -9,7 +9,7 @@ test('package has one executable and only its declared CLI runtime dependencies'
 	assert.equal(pkg.types, undefined);
 	assert.equal(pkg.files.some((path: string) => path.startsWith('scripts/')), false);
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
-	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.85', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
+	assert.deepEqual(pkg.dependencies, { '@treeseed/sdk': '0.13.0-rc.86', ink: '^7.1.1', react: '^19.2.8', 'string-width': '^8.2.2', yaml: '2.9.0' });
 	assert.equal(pkg.devDependencies['@treeseed/ui'], '>=0.12.18-rc.12 <0.14.0');
 });
 

--- a/tests/unit/command-boundary/platform/topology.test.ts
+++ b/tests/unit/command-boundary/platform/topology.test.ts
@@ -11,29 +11,22 @@ const teamId = 'team-treeseed';
 const now = '2026-09-02T12:00:00.000Z';
 const declaration = {
 	schemaVersion: 'treeseed.hosted-topology/v1' as const, id: 'production', teamId, deploymentId: 'treeseed-cloud', stackId: 'control-plane', environment: 'production' as const,
-	mutation: 'approval-required' as const, platform: { repository: 'treeseed-ai/platform' as const, commit: 'a'.repeat(40) }, stateBackend: { connectionRef: 'cloudflare-state' }, providerConnections: {}, artifacts: {}, resources: [],
+	mutation: 'agent-authorized' as const, platform: { repository: 'treeseed-ai/platform' as const, commit: 'a'.repeat(40) }, stateBackend: { connectionRef: 'cloudflare-state' }, providerConnections: {}, artifacts: {}, resources: [],
 };
 const backend = bindHostedStateBackend({ schemaVersion: 'treeseed.hosted-state-backend/v1', type: 's3', teamId, deploymentId: declaration.deploymentId, stackId: declaration.stackId, environment: declaration.environment,
 	connectionRef: 'cloudflare-state', bucket: 'treeseed-state', key: hostedTopologyStateKey(declaration), region: 'auto', endpoint: 'https://example.r2.cloudflarestorage.com', usePathStyle: true, encryptionKeyRef: 'state-key' });
 const plan = planHostedTopology({ declaration, observations: [], connections: {}, stateBackend: backend });
-const planApproval = { schemaVersion: 'treeseed.hosted-topology-approval/v1' as const, planDigest: plan.planDigest, teamId, deploymentId: plan.deploymentId, stackId: plan.stackId, environment: plan.environment, backendBindingDigest: backend.bindingDigest, decision: 'approved' as const, approvedBy: 'owner', approvedAt: now };
 const authorizedPlan = authorizeHostedTopologyPlan(plan);
 const receipt = verifyHostedTopologyReadback({ plan: authorizedPlan, previousResources: [], resources: [], completedAt: now });
 const rollback = planHostedTopologyRollback(receipt);
 const targetPlan = planHostedTopology({ declaration, observations: [], connections: {}, stateBackend: backend });
 const execution = planHostedTopologyRollbackExecution({ rollback, sourceReceipt: receipt, sourcePlan: plan, targetPlan });
-const rollbackApproval = { schemaVersion: 'treeseed.hosted-topology-rollback-execution-approval/v1' as const,
-	executionDigest: execution.executionDigest, teamId, deploymentId: execution.deploymentId, stackId: execution.stackId,
-	environment: execution.environment, backendBindingDigest: execution.backendBindingDigest, decision: 'approved' as const,
-	approvedBy: 'owner', approvedAt: now };
 
 function fixture() {
 	const root = mkdtempSync(resolve(tmpdir(), 'platform-topology-cli-'));
 	writeFileSync(resolve(root, 'topology.yaml'), JSON.stringify(declaration));
 	writeFileSync(resolve(root, 'plan.json'), JSON.stringify(plan));
-	writeFileSync(resolve(root, 'plan-approval.json'), JSON.stringify(planApproval));
 	writeFileSync(resolve(root, 'rollback.json'), JSON.stringify({ execution, sourcePlan: plan, targetPlan }));
-	writeFileSync(resolve(root, 'rollback-approval.json'), JSON.stringify(rollbackApproval));
 	return root;
 }
 
@@ -44,9 +37,10 @@ test('platform topology commands use the active team and canonical API operation
 			calls.push({ operationId, input }); return { data: operationId.endsWith('.plan') ? plan : operationId.endsWith('.status') ? { receipt, operation: null } : { operationId: 'accepted' } };
 		} };
 		assert.equal(await runCommandLine(['platform', 'topology', 'plan', 'topology.yaml', '--json'], context), 0, output.join('\n'));
-		assert.equal(await runCommandLine(['platform', 'topology', 'apply', 'plan.json', '--approval', 'plan-approval.json', '--yes', '--json'], context), 0);
+		assert.equal(await runCommandLine(['platform', 'topology', 'apply', 'plan.json', '--yes', '--json'], context), 0);
 		assert.equal(await runCommandLine(['platform', 'topology', 'status', '--json'], context), 0);
-		assert.equal(await runCommandLine(['platform', 'topology', 'rollback', 'rollback.json', '--approval', 'rollback-approval.json', '--yes', '--json'], context), 0);
+		assert.equal(await runCommandLine(['platform', 'topology', 'rollback', 'rollback.json', '--yes', '--json'], context), 0);
+		assert.ok(!calls.some(({ input }) => input.body && 'approval' in input.body));
 		assert.deepEqual(calls.map(({ operationId }) => operationId), ['infrastructure.topology.plan', 'infrastructure.topology.apply', 'infrastructure.topology.status', 'infrastructure.topology.rollback']);
 		assert.ok(calls.every(({ input }) => input.path.teamId === teamId));
 	} finally { rmSync(root, { recursive: true, force: true }); }
@@ -62,7 +56,7 @@ test('platform topology rejects cross-team custody before invoking the API', asy
 
 test('platform topology compiles a tracked portable template with runtime artifacts and active-team custody', async () => {
 	const root = mkdtempSync(resolve(tmpdir(), 'platform-topology-template-cli-')), output: string[] = [], calls: any[] = [];
-	const template = { schemaVersion: 'treeseed.hosted-topology-template/v1', id: 'staging', deploymentId: 'treeseed-cloud', stackId: 'control-plane', environment: 'staging', mutation: 'approval-required', stateBackend: { connectionRef: 'cloudflare-state' }, providerConnections: { cloudflare: { connectionRef: 'cloudflare-hosting' } }, artifactBindings: { admin: { input: 'admin-pages', kind: 'archive' } }, resources: [{ id: 'admin', provider: 'cloudflare', kind: 'pages-application', dependsOn: [], parameters: { name: { input: 'admin-project-name' }, artifact: { artifact: 'admin' }, 'artifact-format': { literal: 'tar+gzip' }, 'production-branch': { input: 'production-branch' }, 'destination-dir': { literal: '.' } }, adoption: { mode: 'adopt-or-create', replacement: 'forbidden' } }] };
+	const template = { schemaVersion: 'treeseed.hosted-topology-template/v1', id: 'staging', deploymentId: 'treeseed-cloud', stackId: 'control-plane', environment: 'staging', mutation: 'agent-authorized', stateBackend: { connectionRef: 'cloudflare-state' }, providerConnections: { cloudflare: { connectionRef: 'cloudflare-hosting' } }, artifactBindings: { admin: { input: 'admin-pages', kind: 'archive' } }, resources: [{ id: 'admin', provider: 'cloudflare', kind: 'pages-application', dependsOn: [], parameters: { name: { input: 'admin-project-name' }, artifact: { artifact: 'admin' }, 'artifact-format': { literal: 'tar+gzip' }, 'production-branch': { input: 'production-branch' }, 'destination-dir': { literal: '.' } }, adoption: { mode: 'adopt-or-create', replacement: 'forbidden' } }] };
 	const artifacts = { schemaVersion: 'treeseed.hosted-topology-artifacts/v1', artifacts: { 'admin-pages': { kind: 'archive', format: 'tar+gzip', digest: `sha256:${'b'.repeat(64)}`, source: 'https://releases.example.test/admin.tgz' } } };
 	try {
 		writeFileSync(resolve(root, 'topology.yaml'), JSON.stringify(template)); writeFileSync(resolve(root, 'artifacts.json'), JSON.stringify(artifacts));


### PR DESCRIPTION
Closes #127.

Adopts SDK rc86 and removes `--approval` from hosted topology apply and rollback. Authenticated `infrastructure.write`, exact plan custody, API digest preconditions, and explicit `--yes` remain mandatory.

Verification: 110 tests, packed-install smoke, generated command reference/schema, and release verification passed.
