### PR TITLE
Fix RC release environment boundary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,17 +8,18 @@ jobs:
   promote:
     runs-on: ubuntu-24.04
     permissions: { actions: read, contents: write, id-token: write }
-    environment: production
+    environment: ${{ contains(github.ref_name, '-') && 'staging' || 'production' }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 0 }
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: 24, registry-url: https://registry.npmjs.org }
-      - name: Download exact protected staging candidate
+      - name: Download exact protected candidate
         env: { GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}" }
         run: |
-          test "$(git rev-parse HEAD)" = "$(git rev-parse origin/staging)"
-          run_id="$(gh run list --workflow verify.yml --branch staging --commit "$GITHUB_SHA" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then candidate_branch=staging; else candidate_branch=main; fi
+          test "$(git rev-parse HEAD)" = "$(git rev-parse "origin/${candidate_branch}")"
+          run_id="$(gh run list --workflow verify.yml --branch "$candidate_branch" --commit "$GITHUB_SHA" --status success --limit 1 --json databaseId --jq '.[0].databaseId')"
           test -n "$run_id"
           gh run download "$run_id" --name "cli-candidate-${GITHUB_SHA}" --dir candidate
       - name: Install exact published dependency graph

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.57",
+  "version": "0.13.0-rc.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.57",
+      "version": "0.13.0-rc.58",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.57",
+  "version": "0.13.0-rc.58",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -42,12 +42,14 @@ test('the executable drains complete output before exiting', () => {
 	assert.equal(main.includes('process.exitCode = await runCommandLine'), true);
 });
 
-test('candidate promotion installs the exact registry SDK without lifecycle builds', () => {
+test('candidate promotion uses staging while stable publication uses production', () => {
 	const workflow = readFileSync('.github/workflows/publish.yml', 'utf8');
 	const install = workflow.indexOf('npm ci --ignore-scripts --no-audit --no-fund');
 	const verify = workflow.indexOf('npm run release:custody -- verify');
 	assert.equal(workflow.includes('hydrate-exact-sdk.sh'), false);
 	assert.ok(install >= 0 && verify > install);
+	assert.match(workflow, /environment: \$\{\{ contains\(github\.ref_name, '-'\) && 'staging' \|\| 'production' \}\}/u);
+	assert.match(workflow, /candidate_branch=staging; else candidate_branch=main/u);
 });
 
 test('source contains no legacy implementation residue', () => {


### PR DESCRIPTION
Closes #129.

## Outcome

- Routes release-candidate tags through the `staging` GitHub environment.
- Reserves `production` for stable tags cut from the exact protected `main` commit.
- Downloads the immutable verification artifact from the matching protected branch.
- Advances the replacement candidate to `0.13.0-rc.58` because rc57 is immutable and failed publication before execution.

## Verification

- `npm run verify:direct`
- 110 tests pass, including the release boundary contract.
