### PR TITLE
Advance CLI replacement candidate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.58",
+	"version": "0.13.0-rc.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.58",
+			"version": "0.13.0-rc.59",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.58",
+	"version": "0.13.0-rc.59",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Completes #129 after the immutable rc58 tag was correctly rejected by the pre-existing staging environment ref policy.

The repository staging environment now admits both the protected `staging` branch and RC tags, with no reviewers or wait timer. This advances the publishable replacement to `0.13.0-rc.59`; the tested release workflow remains unchanged from PR #130.

Verification: focused release-boundary package contract passes.
