### PR TITLE
fix: canonical provider registration handoff (rc61)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.60",
+  "version": "0.13.0-rc.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.60",
+      "version": "0.13.0-rc.61",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.60",
+  "version": "0.13.0-rc.61",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/application/launch.tsx
+++ b/src/cli/application/launch.tsx
@@ -46,9 +46,9 @@ export async function launchApplication(context: CommandContext, options: { serv
 		if (id !== 'providers.connect') return response;
 		const envelope = response && typeof response === 'object' && !Array.isArray(response) ? response as Row : {};
 		const value = envelope.data && typeof envelope.data === 'object' && !Array.isArray(envelope.data) ? envelope.data as Row : envelope;
-		const enrollmentToken = typeof value.enrollmentToken === 'string' ? value.enrollmentToken : '';
-		if (!enrollmentToken || !context.providerEnrollmentHandoff) throw Object.assign(new Error('The control plane did not return a usable local provider enrollment handoff.'), { category: 'provider_unavailable', code: 'provider_enrollment_handoff_invalid' });
-		const receipt = await context.providerEnrollmentHandoff({ action: 'begin', ...value, enrollmentToken,
+		const registrationCode = typeof value.registrationCode === 'string' ? value.registrationCode : '';
+		if (!registrationCode || !context.providerEnrollmentHandoff) throw Object.assign(new Error('The control plane did not return a usable local provider enrollment handoff.'), { category: 'provider_unavailable', code: 'provider_enrollment_handoff_invalid' });
+		const receipt = await context.providerEnrollmentHandoff({ action: 'begin', ...value, registrationCode,
 			controlPlaneUrl: selected.profile.baseUrl, controlPlaneAudience: selected.profile.baseUrl, serverProfile: selected.profile.serverId });
 		return { teamId: value.teamId, connectionState: 'approval_required', provider: receipt };
 	};

--- a/src/cli/commands/operator.ts
+++ b/src/cli/commands/operator.ts
@@ -164,7 +164,7 @@ export async function runOperator(invocation: ParsedInvocation, context: Command
 		if (!enrollments.length) return response;
 		if (!context.providerEnrollmentHandoff) throw Object.assign(new Error('The seeded local provider requires the protected host enrollment handoff.'), { category: 'provider_unavailable', code: 'provider_enrollment_handoff_unavailable' });
 		for (const enrollment of enrollments) {
-			if (enrollment.approval !== 'trusted-local-owner' || typeof enrollment.enrollmentToken !== 'string' || typeof enrollment.teamId !== 'string' || typeof enrollment.connectionId !== 'string') {
+			if (enrollment.approval !== 'trusted-local-owner' || typeof enrollment.registrationCode !== 'string' || typeof enrollment.teamId !== 'string' || typeof enrollment.connectionId !== 'string') {
 				throw Object.assign(new Error('The seeded provider enrollment receipt is incomplete or not trusted-local-owner.'), { category: 'provider_unavailable', code: 'seed_provider_enrollment_invalid' });
 			}
 			const begun = await context.providerEnrollmentHandoff({ action: 'begin', ...enrollment,
@@ -196,9 +196,9 @@ export async function runOperator(invocation: ParsedInvocation, context: Command
 			: envelope;
 		if (['seeds.apply', 'seeds.reconcile'].includes(operation.descriptor.operationId)) return completeSeedProviderEnrollment(response, value);
 		if (operation.descriptor.operationId === 'providers.connect') {
-			const enrollmentToken = typeof value.enrollmentToken === 'string' ? value.enrollmentToken : null;
-			if (!enrollmentToken || !context.providerEnrollmentHandoff) throw Object.assign(new Error('The control plane did not return a usable local provider enrollment handoff.'), { category: 'provider_unavailable', code: 'provider_enrollment_handoff_invalid' });
-			const receipt = await context.providerEnrollmentHandoff({ action: 'begin', ...value, enrollmentToken,
+			const registrationCode = typeof value.registrationCode === 'string' ? value.registrationCode : null;
+			if (!registrationCode || !context.providerEnrollmentHandoff) throw Object.assign(new Error('The control plane did not return a usable local provider enrollment handoff.'), { category: 'provider_unavailable', code: 'provider_enrollment_handoff_invalid' });
+			const receipt = await context.providerEnrollmentHandoff({ action: 'begin', ...value, registrationCode,
 				controlPlaneUrl: profile.baseUrl, controlPlaneAudience: profile.baseUrl, serverProfile: profile.serverId });
 			return { teamId: value.teamId, connectionState: 'approval_required', provider: receipt };
 		}

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -292,13 +292,13 @@ test('seed verify accepts a portable bundle path and derives its seed identity',
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
 
-test('provider enrollment hands the unwrapped API receipt to trusted local custody', async () => {
+for (const field of ['registrationCode', 'enrollmentToken']) test(`provider enrollment accepts only canonical registrationCode (${field})`, async () => {
 	let requestBody = '';
 	const server = createServer((request, response) => {
 		request.on('data', (chunk) => { requestBody += String(chunk); });
 		request.on('end', () => {
 			response.setHeader('content-type', 'application/json');
-			response.end(JSON.stringify({ data: { teamId: 'team-1', enrollmentToken: 'one-time' } }));
+			response.end(JSON.stringify({ data: { teamId: 'team-1', [field]: 'one-time' } }));
 		});
 	});
 	await new Promise<void>((accept) => server.listen(0, '127.0.0.1', accept));
@@ -317,9 +317,16 @@ test('provider enrollment hands the unwrapped API receipt to trusted local custo
 			providerEnrollmentHandoff: async (input) => { handoffs.push(input); return { requestId: 'request-1' }; },
 			write: (value) => output.push(value),
 		});
+		assert.equal(output.join('').includes('one-time'), false);
+		if (field !== 'registrationCode') {
+			assert.notEqual(exit, 0);
+			assert.equal(handoffs.length, 0);
+			assert.equal(JSON.parse(output[0]!).error.code, 'provider_enrollment_handoff_invalid');
+			return;
+		}
 		assert.equal(exit, 0);
 		assert.equal(requestBody, '{}');
-		assert.equal(handoffs[0]?.enrollmentToken, 'one-time');
+		assert.equal(handoffs[0]?.registrationCode, 'one-time');
 		assert.deepEqual(JSON.parse(output[0]!).result, {
 			teamId: 'team-1', connectionState: 'approval_required', provider: { requestId: 'request-1' },
 		});
@@ -335,7 +342,7 @@ test('seed apply enrolls, owner-approves, and waits for execution-ready provider
 		request.resume(); request.on('end', () => {
 			paths.push(request.url ?? ''); response.setHeader('content-type', 'application/json');
 			if (request.url?.endsWith('/apply')) response.end(JSON.stringify({ data: { seed: 'treeseed', result: { providerClosure: { status: 'waiting_provider', receipts: [{
-				key: 'capacity-provider:treeseed/local', status: 'enrollment_required', approval: 'trusted-local-owner', teamId: 'team-1', connectionId: 'local-team-1', enrollmentToken: 'one-time',
+				key: 'capacity-provider:treeseed/local', status: 'enrollment_required', approval: 'trusted-local-owner', teamId: 'team-1', connectionId: 'local-team-1', registrationCode: 'one-time',
 			}] } } } }));
 			else if (request.url?.includes('/capacity-provider-requests/')) response.end(JSON.stringify({ data: { status: 'approved' } }));
 			else response.end(JSON.stringify({ data: { seed: 'treeseed', result: { providerClosure: { status: 'verified', receipts: [{ status: 'verified' }] } } } }));


### PR DESCRIPTION
Closes #136. Supports Deployment #493 live custody acceptance.

## Contract
CLI and interactive application use API/Agent registrationCode exclusively. Trusted-local-owner seed enrollment uses the same field. No enrollmentToken compatibility alias. Registration code remains in protected in-memory handoff and is not returned in the command result.

## Verification
Boundary coverage for canonical handoff, retired field rejection, output redaction and seeded enrollment. Actions are authoritative; publish exact protected staging candidate as rc61 after passing checks.

## Deployment
Paired with Deployment #497 manager/supervisor canonical field fix. Preserve converted host identity; no purge, re-enrollment identity generation or production mutation.