### PR TITLE
test: prefer Codex subscription file while supporting API keys

### DIFF
--- a/tests/unit/command-boundary/host-security.test.ts
+++ b/tests/unit/command-boundary/host-security.test.ts
@@ -32,3 +32,28 @@ test('provider credential initialization is discovered and sent through the prot
 		assert.deepEqual(JSON.parse(calls[1].options.payload), { sourceId: 'chatgpt-subscription', secret: credential });
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
+
+for (const scenario of ['subscription-first', 'explicit-api-key', 'api-key-without-file']) test(`Codex supports both authentication modes: ${scenario}`, async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-credential-precedence-'));
+	const subscription = JSON.stringify({ auth_mode: 'chatgpt', tokens: { access_token: 'synthetic-subscription' } });
+	const calls: any[] = [], output: string[] = []; let prompts = 0;
+	try {
+		if (scenario !== 'api-key-without-file') {
+			mkdirSync(resolve(root, '.codex')); writeFileSync(resolve(root, '.codex/auth.json'), subscription);
+		}
+		const initializer = { id: 'treeseed.codex', displayName: 'Codex', description: 'Registered credential', sources: [
+			{ id: 'service-api-key', label: 'API key', kind: 'secret', prompt: 'API key', suggestedPaths: [] },
+			{ id: 'chatgpt-subscription', label: 'Subscription', kind: 'file', prompt: 'Auth file', suggestedPaths: ['$HOME/.codex/auth.json'] },
+		] };
+		const exit = await runCommandLine(['host', 'provider', 'credentials', 'initialize', 'treeseed.codex', '--yes', '--json', ...(scenario === 'explicit-api-key' ? ['--source', 'service-api-key'] : [])], {
+			env: { HOME: root }, interactiveUi: false, promptSecret: async () => { prompts++; return 'synthetic-api-key'; },
+			hostInvoke: async input => { calls.push(input); return input.handlerId.endsWith('.list') ? { initializers: [initializer] } : { configured: true }; },
+			write: value => output.push(value),
+		});
+		assert.equal(exit, 0);
+		const useSubscription = scenario === 'subscription-first';
+		assert.equal(prompts, useSubscription ? 0 : 1);
+		assert.deepEqual(JSON.parse(calls[1].options.payload), { sourceId: useSubscription ? 'chatgpt-subscription' : 'service-api-key', secret: useSubscription ? subscription : 'synthetic-api-key' });
+		assert.equal(output.join('').includes('synthetic-'), false);
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
Closes #138. User-directed credential policy for Deployment #493.

Existing released behavior is retained: discovered subscription files take priority even when registry ordering lists the API-key source first; --source service-api-key overrides discovery; absent files fall back to the API-key prompt. Synthetic regression tests cover all three and verify no credential output.

All five focused host-security tests pass. Tests only: no runtime change, new credential or duplicate release. Live host auto-selected chatgpt-subscription, encrypted via protected initializer, configured=true and sandboxReady=true.