### PR TITLE
fix(services): validate saved credentials with the parsed version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.89",
+        "@treeseed/sdk": "0.13.0-rc.91",
         "ink": "^7.1.1",
         "react": "^19.2.8",
         "string-width": "^8.2.2",
@@ -4686,9 +4686,10 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.89",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.89.tgz",
-      "integrity": "sha512-aeeIByXTUjPSLN85jAJDu0xCLb0KahTRVHoCT6s0ZDgwm0RVOQPJZ7cdHTs3OpfQSNWzN23gEjyILXO+zUVV7g==",
+      "version": "0.13.0-rc.91",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.91.tgz",
+      "integrity": "sha512-BITFrVggd0QE/xwi3Q6uPms93ka6uF7X8ABLDjoJJsl+XP+7BUduT5i88vG2DFWCAgnTddG1LBJZEDNMEvNP7Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.4",
         "esbuild": "^0.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.61",
+  "version": "0.13.0-rc.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.61",
+      "version": "0.13.0-rc.62",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.61",
+  "version": "0.13.0-rc.62",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.89",
+    "@treeseed/sdk": "0.13.0-rc.91",
     "ink": "^7.1.1",
     "react": "^19.2.8",
     "string-width": "^8.2.2",

--- a/src/cli/commands/services/credentials.ts
+++ b/src/cli/commands/services/credentials.ts
@@ -15,7 +15,9 @@ export async function runServiceCredentials(invocation:ParsedInvocation,context:
   const teamId=String(invocation.options.team ?? clientContext?.session?.activeTeam?.id ?? '');
   const path={teamId,connectionId:invocation.arguments[0]!,profileId:invocation.arguments[1]!};
   operation.schema.path.parse(path);
-  const expectedVersion=Number(invocation.options['expected-version']);
+  const expectedVersion=Number(invocation.options.expectedVersion);
+  if(name!=='show'&&(!Number.isSafeInteger(expectedVersion)||expectedVersion<0||expectedVersion>=Number.MAX_SAFE_INTEGER))
+    throw Object.assign(new Error('--expected-version must be the current nonnegative credential version (zero for first creation).'),{category:'invalid_input',code:'credential_version_invalid'});
   const invoke=async (binding:any,input:any)=>context.operationInvoke
     ? context.operationInvoke(binding.descriptor.operationId,input,{idempotencyKey:randomUUID()})
     : clientContext!.client.invoke(binding,input,{idempotencyKey:randomUUID()});

--- a/tests/unit/command-boundary/services/credentials.test.ts
+++ b/tests/unit/command-boundary/services/credentials.test.ts
@@ -1,8 +1,20 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { runServiceCredentials } from '../../../../src/cli/commands/services/credentials.ts';
-const invocation=(name:string,options:Record<string,any>={})=>({command:{name:`services credentials ${name}`,path:['services','credentials',name]},arguments:['connection-1','railway-workspace'],options:{team:'team-1','expected-version':'0',...options}} as any);
+import { parseInvocation } from '../../../../src/cli/parser.ts';
+import { resolveCommand } from '../../../../src/cli/registry.ts';
+const invocation=(name:string,options:Record<string,any>={})=>({command:{name:`services credentials ${name}`,path:['services','credentials',name]},arguments:['connection-1','railway-workspace'],options:{team:'team-1',expectedVersion:0,...options}} as any);
 const context=(operationInvoke:any)=>({cwd:'.',env:{},write(){},outputFormat:'json' as const,interactiveUi:false,operationInvoke});
+test('validates saved credentials without requesting secret input',async()=>{
+  let recorded:any;
+  const resolved=resolveCommand(['services','credentials','validate','connection-1','railway-workspace','--team','team-1','--expected-version','1'])!;
+  await runServiceCredentials(parseInvocation(resolved.command,resolved.rest),{...context(async(id:any,input:any)=>{recorded={id,input};return{data:{ok:true}};}),readStdin:()=>{throw Error('must not read secrets');}});
+  assert.equal(recorded.id,'services.credentials.validate');
+  assert.deepEqual(recorded.input.body,{expectedVersion:1});
+});
+test('reports missing versions without misleading secret-input advice',async()=>{
+  await assert.rejects(runServiceCredentials(invocation('validate',{expectedVersion:undefined}),context(()=>{throw Error('must not invoke');})),{code:'credential_version_invalid'});
+});
 test('puts stdin credentials with exact CAS and returns metadata only',async()=>{
   let recorded:any;
   const output=await runServiceCredentials(invocation('put',{stdin:true}),{...context(async(id:any,input:any,options:any)=>{


### PR DESCRIPTION
Closes #140. Read canonical expectedVersion rather than a dashed key; give precise version diagnostics. Saved credential validation never prompts or reads secret input. CLI rc62.

Verification: five tests pass, including actual registry/parser invocation with --expected-version; build passed. Actions required.