### PR TITLE
fix(dev): delegate container lifecycle and isolate session state

### DIFF
--- a/src/cli/commands/development-support/host-runtime.ts
+++ b/src/cli/commands/development-support/host-runtime.ts
@@ -35,6 +35,7 @@ export function hostDevelopmentRuntimeManifest(worktree: string) {
 		if (!path.startsWith(`${sdkRoot}/`)) return true;
 		const sdkPath = relative(sdkRoot, path);
 		return sdkPath === 'package.json' || sdkPath.startsWith('dist/deployment/') || sdkPath.startsWith('dist/development/')
+			|| sdkPath.startsWith('dist/secrets-capability/') || sdkPath === 'dist/configuration/secrets-capability.js'
 			|| sdkPath.startsWith('dist/capacity-provider/contracts/')
 			|| sdkPath === 'dist/capacity-provider/sandbox.js' || sdkPath === 'dist/capacity-provider/sandbox-contracts.js';
 	};

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -343,7 +343,7 @@ async function restart(invocation: ParsedInvocation, context: CommandContext, st
 	const repository = record.session.repositories.find((entry) => entry.projectId === selection.projectId);
 	if (!repository) throw new Error(`No worktree is registered for ${selection.projectId}.`);
 	await restartConsumer({ state, runtime, target, worktree: repository.worktree, mode: selected.mode as 'candidate' | 'live', context, recordGeneration: false });
-	await invoke(context, 'local.dev.use', { sessionId, projectId: selection.projectId, targetId: selection.targetId, mode: selected.mode });
+	await invoke(context, 'local.dev.use', { sessionId, projectId: selection.projectId, targetId: selection.targetId, mode: selected.mode, ...(target.endpoints[0] ? { port: target.endpoints[0].port } : {}) });
 	saveState(state, context.env);
 	return { sessionId, target: `${selection.projectId}.${selection.targetId}`, restarted: true, record: await invoke(context, 'local.dev.status', { sessionId, all: false }) };
 }

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -236,7 +236,7 @@ async function useTargets(invocation: ParsedInvocation, context: CommandContext)
 }
 
 async function freeze(invocation: ParsedInvocation, context: CommandContext) {
-	const state = loadState(context.env), sessionId = String(invocation.options.session ?? state.sessionId), record = await invoke(context, 'local.dev.status', { sessionId, all: false }) as { session: { repositories: Array<{ projectId: string; worktree: string; dirty: boolean }>; targets: Array<{ projectId: string; targetId: string; mode: string; generation: number }> }; runtimes: DevelopmentRuntime[] };
+	const state = loadState(context.env,invocation.options.session), sessionId = String(invocation.options.session ?? state.sessionId), record = await invoke(context, 'local.dev.status', { sessionId, all: false }) as { session: { repositories: Array<{ projectId: string; worktree: string; dirty: boolean }>; targets: Array<{ projectId: string; targetId: string; mode: string; generation: number }> }; runtimes: DevelopmentRuntime[] };
 	return withFreezeLock(context.env, sessionId, async () => {
 		const source = record.session.repositories.map((repository) => {
 		const runtime = record.runtimes.find((entry) => entry.project.id === repository.projectId);
@@ -395,7 +395,7 @@ export async function runDevelopment(invocation: ParsedInvocation, context: Comm
 	if (invocation.command.name.startsWith('dev host ')) return runHostDevelopment(invocation, context);
 	if (invocation.command.name === 'dev session start') return startSession(invocation, context);
 	if (invocation.command.name === 'dev use') return useTargets(invocation, context);
-	const state = loadState(context.env), sessionId = String(invocation.options.session ?? state.sessionId);
+	const state = loadState(context.env,invocation.options.session), sessionId = String(invocation.options.session ?? state.sessionId);
 	if (invocation.command.name === 'dev session stop') {
 		if (invocation.options.plan === true) return { sessionId, restore: true, mutation: false };
 		const running = await stopProcesses(state);

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -39,12 +39,20 @@ function saveState(state: LocalSessionState, env: NodeJS.ProcessEnv) {
 	const path = statePath(env), temporary = `${path}.new`;
 	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
 	writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 }); renameSync(temporary, path);
+	const snapshot=resolve(developmentStateRoot(env),state.sessionId,'session.json');
+	mkdirSync(dirname(snapshot),{recursive:true,mode:0o700});
+	writeFileSync(`${snapshot}.new`,`${JSON.stringify(state,null,2)}\n`,{mode:0o600});renameSync(`${snapshot}.new`,snapshot);
 }
 
-function loadState(env: NodeJS.ProcessEnv) {
+function loadState(env: NodeJS.ProcessEnv, sessionId?: unknown) {
 	const path = statePath(env);
 	if (!existsSync(path)) throw new Error('No local development session is selected.');
-	return JSON.parse(readFileSync(path, 'utf8')) as LocalSessionState;
+	const current=JSON.parse(readFileSync(path, 'utf8')) as LocalSessionState;
+	if(sessionId===undefined||sessionId===current.sessionId)return current;
+	if(typeof sessionId!=='string'||!/^dev-[a-z0-9-]{1,64}$/.test(sessionId))throw new Error('Invalid development session identity.');
+	const snapshot=resolve(developmentStateRoot(env),sessionId,'session.json');
+	if(!existsSync(snapshot))throw new Error('Local state for the requested development session is unavailable; no other session was changed.');
+	return JSON.parse(readFileSync(snapshot,'utf8')) as LocalSessionState;
 }
 
 function sha256(value: string | Buffer) { return `sha256:${createHash('sha256').update(value).digest('hex')}`; }
@@ -109,6 +117,14 @@ function operationForMode(target: DevelopmentTarget, mode: string) {
 	if (target.kind === 'rebuild-restart') return target.operations.start ?? null;
 	if (mode === 'candidate') return target.operations.build ?? target.operations.start ?? null;
 	return target.operations.start ?? null;
+}
+
+export function usesManagedContainer(target: DevelopmentTarget) {
+	return target.operations.start?.command === 'docker';
+}
+
+async function containerOperation(context: CommandContext, sessionId: string, runtime: DevelopmentRuntime, target: DevelopmentTarget, action: 'start' | 'stop') {
+	return invoke(context, 'local.dev.container', {sessionId,projectId:runtime.project.id,targetId:target.id,action});
 }
 
 export function developmentOperationEnvironment(state: Pick<LocalSessionState, 'manifest' | 'sessionId'>, worktree: string, mode: string, env: NodeJS.ProcessEnv, resolvedEnvironment: NodeJS.ProcessEnv = {}, operationEnvironment: NodeJS.ProcessEnv = {}) {
@@ -179,7 +195,7 @@ async function startSession(invocation: ParsedInvocation, context: CommandContex
 }
 
 async function useTargets(invocation: ParsedInvocation, context: CommandContext) {
-	const state = loadState(context.env), sessionId = String(invocation.options.session ?? state.sessionId);
+	const state = loadState(context.env,invocation.options.session), sessionId = String(invocation.options.session ?? state.sessionId);
 	const record = await invoke(context, 'local.dev.status', { sessionId, all: false }) as { session: { expiresAt: string; repositories: Array<{ projectId: string; worktree: string }> }; runtimes: DevelopmentRuntime[] };
 	const selections = [invocation.arguments[0]!, ...(Array.isArray(invocation.options.target) ? invocation.options.target : [])].map(parseSelection);
 	if (invocation.options.plan === true) return { sessionId, selections, mutation: false };
@@ -188,12 +204,14 @@ async function useTargets(invocation: ParsedInvocation, context: CommandContext)
 		const repository = (record as { session: { repositories: Array<{ projectId: string; worktree: string }> } }).session.repositories.find((entry) => entry.projectId === selection.projectId);
 		if (!repository) throw new Error(`No worktree is registered for ${selection.projectId}.`);
 		if (selection.mode === 'released') {
+			if (usesManagedContainer(target)) await invoke(context, 'local.dev.use', {sessionId,...selection});
 			const processState = state.processes[`${selection.projectId}.${selection.targetId}`];
 			if (processState) {
 				await stopProcesses({ ...state, processes: { [`${selection.projectId}.${selection.targetId}`]: processState } });
 				delete state.processes[`${selection.projectId}.${selection.targetId}`];
 			}
-			if (target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, repository.worktree, selection.mode, context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'session' });
+			if (usesManagedContainer(target)) await containerOperation(context, sessionId, runtime, target, 'stop');
+			else if (target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, repository.worktree, selection.mode, context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'session' });
 			restoreOverlays(state, selection.projectId);
 			if (selection.projectId === 'cli' && selection.targetId === 'package') selectDevelopmentCli(context.env, null);
 		} else {
@@ -201,7 +219,8 @@ async function useTargets(invocation: ParsedInvocation, context: CommandContext)
 			if (target.operations.setup) runOneShotOperation(state, target.operations.setup, repository.worktree, selection.mode, context.env, resolved.environment ?? {});
 			const running = operationIsRunning(state, `${runtime.project.id}.${target.id}`);
 			if (target.kind === 'rebuild-restart' && target.operations.build && !running) runOneShotOperation(state, target.operations.build, repository.worktree, selection.mode, context.env, resolved.environment ?? {});
-			startOperation(state, runtime, target, repository.worktree, selection.mode, context.env, resolved.environment ?? {});
+			if (usesManagedContainer(target)) await containerOperation(context, sessionId, runtime, target, 'start');
+			else startOperation(state, runtime, target, repository.worktree, selection.mode, context.env, resolved.environment ?? {});
 			saveState(state, context.env);
 			if (target.kind === 'package-watch') {
 				const cliWorktree = record.session.repositories.find((entry) => entry.projectId === 'cli')?.worktree;
@@ -209,7 +228,7 @@ async function useTargets(invocation: ParsedInvocation, context: CommandContext)
 				saveState(state, context.env);
 				await waitForPackageOverlay(target, repository.worktree, overlayRoot); installPackageOverlay(state, record, runtime, target, repository.worktree, overlayRoot); saveState(state, context.env);
 				if (selection.projectId === 'cli' && selection.targetId === 'package') selectDevelopmentCli(context.env, { entrypoint: resolve(overlayRoot, 'current', 'dist', 'cli', 'main.js'), expiresAt: record.session.expiresAt });
-			} else await waitForDirectReadiness(target, target.ready.kind === 'process' ? target.ready.graceSeconds : target.ready.timeoutSeconds, state, `${runtime.project.id}.${target.id}`);
+			} else if (!usesManagedContainer(target)) await waitForDirectReadiness(target, target.ready.kind === 'process' ? target.ready.graceSeconds : target.ready.timeoutSeconds, state, `${runtime.project.id}.${target.id}`);
 		}
 		await invoke(context, 'local.dev.use', { sessionId, ...selection, ...(selection.mode !== 'released' && target.endpoints[0] ? { port: target.endpoints[0].port } : {}) });
 	}
@@ -248,7 +267,7 @@ async function freeze(invocation: ParsedInvocation, context: CommandContext) {
 }
 
 async function verifyCandidate(invocation: ParsedInvocation, context: CommandContext) {
-	const state = loadState(context.env), sessionId = String(invocation.options.session ?? state.sessionId);
+	const state = loadState(context.env,invocation.options.session), sessionId = String(invocation.options.session ?? state.sessionId);
 	const selected = typeof invocation.options.candidate === 'string' ? state.candidates.find((path) => path.includes(invocation.options.candidate as string)) : state.candidates.at(-1);
 	if (!selected || !existsSync(selected)) throw new Error('No local development candidate is available for verification.');
 	const candidate = developmentCandidateSchema.parse(JSON.parse(readFileSync(selected, 'utf8')));
@@ -294,13 +313,18 @@ async function rebuildPackage(input: { state: LocalSessionState; runtime: Develo
 
 async function restartConsumer(input: { state: LocalSessionState; runtime: DevelopmentRuntime; target: DevelopmentTarget; worktree: string; mode: 'candidate' | 'live'; context: CommandContext; recordGeneration?: boolean }) {
 	const { state, runtime, target, worktree, mode, context } = input, key = `${runtime.project.id}.${target.id}`;
+	if (usesManagedContainer(target)) await invoke(context, 'local.dev.use', {sessionId:state.sessionId,projectId:runtime.project.id,targetId:target.id,mode:'released'});
 	await stopProcess(state, key);
-	if (target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, worktree, mode, context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'runtime' });
+	if (usesManagedContainer(target)) await containerOperation(context, state.sessionId, runtime, target, 'stop');
+	else if (target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, worktree, mode, context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'runtime' });
 	const resolved = await invoke(context, 'local.dev.environment', { sessionId: state.sessionId, projectId: runtime.project.id, targetId: target.id }) as { environment?: NodeJS.ProcessEnv };
 	if (target.operations.setup) runOneShotOperation(state, target.operations.setup, worktree, mode, context.env, resolved.environment ?? {});
 	if (!target.operations.start && target.kind === 'rebuild-restart' && target.operations.build) {
 		runOneShotOperation(state, target.operations.build, worktree, mode, context.env, resolved.environment ?? {});
 		await waitForDirectReadiness(target, target.ready.kind === 'process' ? target.ready.graceSeconds : target.ready.timeoutSeconds);
+	} else if (usesManagedContainer(target)) {
+		if (target.kind === 'rebuild-restart' && target.operations.build) runOneShotOperation(state, target.operations.build, worktree, mode, context.env, resolved.environment ?? {});
+		await containerOperation(context, state.sessionId, runtime, target, 'start');
 	} else {
 		startOperation(state, runtime, target, worktree, mode, context.env, resolved.environment ?? {});
 		saveState(state, context.env);
@@ -376,7 +400,10 @@ export async function runDevelopment(invocation: ParsedInvocation, context: Comm
 		if (invocation.options.plan === true) return { sessionId, restore: true, mutation: false };
 		const running = await stopProcesses(state);
 		const active = new Set(running.map((entry) => `${entry.projectId}.${entry.targetId}`));
-		for (const { selection, runtime } of loadRuntimes(state.manifest)) for (const target of runtime.targets) if (active.has(`${runtime.project.id}.${target.id}`) && target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, selection.worktree!, 'released', context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'session' });
+		for (const { selection, runtime } of loadRuntimes(state.manifest)) for (const target of runtime.targets) {
+			if (usesManagedContainer(target)) await containerOperation(context, sessionId, runtime, target, 'stop');
+			else if (active.has(`${runtime.project.id}.${target.id}`) && target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, selection.worktree!, 'released', context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'session' });
+		}
 		restoreOverlays(state); selectDevelopmentCli(context.env, null); saveState(state, context.env); return invoke(context, 'local.dev.session.stop', { sessionId });
 	}
 	if (invocation.command.name === 'dev status') return invoke(context, 'local.dev.status', { ...(invocation.options.session ? { sessionId } : {}), all: invocation.options.all === true });

--- a/tests/unit/command-boundary/managed-development-container.test.ts
+++ b/tests/unit/command-boundary/managed-development-container.test.ts
@@ -16,18 +16,23 @@ test('container startup and cleanup only invoke the protected manager, including
     const file=resolve(root,'treeseed.package.yaml');writeFileSync(file,JSON.stringify({development:runtime}));
     execFileSync('git',['init','-b','staging'],{cwd:root});execFileSync('git',['add','.'],{cwd:root});
     execFileSync('git',['-c','user.name=Test','-c','user.email=test@example.invalid','commit','-m','fixture'],{cwd:root});
-    let record:any;const actions:string[]=[];
+    let record:any;const actions:string[]=[],records=new Map<string,any>();let selected='';
     const context={cwd:root,env:{XDG_STATE_HOME:resolve(root,'state'),USER:'tester'},interactiveUi:false,write:()=>{},hostInvoke:async(request:any)=>{
       const payload=JSON.parse(request.options.payload);
-      if(request.handlerId==='local.dev.session.start'){record={session:payload.session,runtimes:payload.runtimes};return record;}
+      if(request.handlerId==='local.dev.session.start'){record={session:payload.session,runtimes:payload.runtimes};records.set(payload.session.sessionId,record);return record;}
+      record=records.get(payload.sessionId)??record;
       if(request.handlerId==='local.dev.environment')return {environment:{}};
-      if(request.handlerId==='local.dev.container'){actions.push(payload.action);return {};}
+      if(request.handlerId==='local.dev.container'){assert.equal(payload.sessionId,selected);actions.push(payload.action);return {};}
+      if(request.handlerId==='local.dev.use')record.session.targets[0].mode=payload.mode;
       return record;
     }};
     assert.equal(await runCommandLine(['dev','session','start',file,'--json'],context),0);
-    assert.equal(await runCommandLine(['dev','use','api.service=live','--json'],context),0);
-    assert.equal(await runCommandLine(['dev','use','api.service=released','--json'],context),0);
-    assert.equal(await runCommandLine(['dev','session','stop','--json'],context),0);
-    assert.deepEqual(actions,['start','stop','stop']);
+    selected=record.session.sessionId;
+    assert.equal(await runCommandLine(['dev','session','start',file,'--json'],context),0);
+    assert.equal(await runCommandLine(['dev','use','api.service=live','--session',selected,'--json'],context),0);
+    assert.equal(await runCommandLine(['dev','restart','api.service','--session',selected,'--json'],context),0);
+    assert.equal(await runCommandLine(['dev','use','api.service=released','--session',selected,'--json'],context),0);
+    assert.equal(await runCommandLine(['dev','session','stop','--session',selected,'--json'],context),0);
+    assert.deepEqual(actions,['start','stop','start','stop','stop']);
   } finally {rmSync(root,{recursive:true,force:true});}
 });

--- a/tests/unit/command-boundary/managed-development-container.test.ts
+++ b/tests/unit/command-boundary/managed-development-container.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import {execFileSync} from 'node:child_process';
+import {mkdtempSync,writeFileSync,rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {resolve} from 'node:path';
+import test from 'node:test';
+import {runCommandLine} from '../../../src/cli/runtime.ts';
+test('container startup and cleanup only invoke the protected manager, including failed-start cleanup',async()=>{
+  const root=mkdtempSync(resolve(tmpdir(),'treeseed-managed-dev-'));
+  try {
+    const target={id:'service',kind:'live-api',platforms:['linux-amd64'],runtimeRequirements:[],sourceRoots:['src'],ignoredPaths:[],
+      operations:{start:{command:'docker',args:['must-not-run'],environment:{},timeoutSeconds:10},cleanup:{command:'node',args:['-e','throw Error("unprivileged cleanup ran")'],environment:{},timeoutSeconds:10}},
+      ready:{kind:'http',path:'/health',expectedStatus:200,timeoutSeconds:1},outputs:[],endpoints:[],dependencies:[],statePolicy:'stateless',migrationPolicy:'none',secretRefs:{},
+      shutdown:{graceSeconds:1,activeWorkPolicy:'block'},resources:{},logs:[],forbiddenOperations:[],promotion:{liveAdmissible:false,candidateRequiresVerification:true}};
+    const runtime={schemaVersion:'treeseed.development-runtime/v1',project:{id:'api',repository:'treeseed-ai/api'},defaults:{leaseSeconds:600,restoreOnFailure:true},targets:[target]};
+    const file=resolve(root,'treeseed.package.yaml');writeFileSync(file,JSON.stringify({development:runtime}));
+    execFileSync('git',['init','-b','staging'],{cwd:root});execFileSync('git',['add','.'],{cwd:root});
+    execFileSync('git',['-c','user.name=Test','-c','user.email=test@example.invalid','commit','-m','fixture'],{cwd:root});
+    let record:any;const actions:string[]=[];
+    const context={cwd:root,env:{XDG_STATE_HOME:resolve(root,'state'),USER:'tester'},interactiveUi:false,write:()=>{},hostInvoke:async(request:any)=>{
+      const payload=JSON.parse(request.options.payload);
+      if(request.handlerId==='local.dev.session.start'){record={session:payload.session,runtimes:payload.runtimes};return record;}
+      if(request.handlerId==='local.dev.environment')return {environment:{}};
+      if(request.handlerId==='local.dev.container'){actions.push(payload.action);return {};}
+      return record;
+    }};
+    assert.equal(await runCommandLine(['dev','session','start',file,'--json'],context),0);
+    assert.equal(await runCommandLine(['dev','use','api.service=live','--json'],context),0);
+    assert.equal(await runCommandLine(['dev','use','api.service=released','--json'],context),0);
+    assert.equal(await runCommandLine(['dev','session','stop','--json'],context),0);
+    assert.deepEqual(actions,['start','stop','stop']);
+  } finally {rmSync(root,{recursive:true,force:true});}
+});

--- a/tests/unit/command-boundary/managed-development-container.test.ts
+++ b/tests/unit/command-boundary/managed-development-container.test.ts
@@ -10,7 +10,7 @@ test('container startup and cleanup only invoke the protected manager, including
   try {
     const target={id:'service',kind:'live-api',platforms:['linux-amd64'],runtimeRequirements:[],sourceRoots:['src'],ignoredPaths:[],
       operations:{start:{command:'docker',args:['must-not-run'],environment:{},timeoutSeconds:10},cleanup:{command:'node',args:['-e','throw Error("unprivileged cleanup ran")'],environment:{},timeoutSeconds:10}},
-      ready:{kind:'http',path:'/health',expectedStatus:200,timeoutSeconds:1},outputs:[],endpoints:[],dependencies:[],statePolicy:'stateless',migrationPolicy:'none',secretRefs:{},
+      ready:{kind:'http',path:'/health',expectedStatus:200,timeoutSeconds:1},outputs:[],endpoints:[{id:'http',protocol:'http',port:3000,visibility:'host',canonicalAlias:'api.treeseed.localhost',authentication:'application'}],dependencies:[],statePolicy:'stateless',migrationPolicy:'none',secretRefs:{},
       shutdown:{graceSeconds:1,activeWorkPolicy:'block'},resources:{},logs:[],forbiddenOperations:[],promotion:{liveAdmissible:false,candidateRequiresVerification:true}};
     const runtime={schemaVersion:'treeseed.development-runtime/v1',project:{id:'api',repository:'treeseed-ai/api'},defaults:{leaseSeconds:600,restoreOnFailure:true},targets:[target]};
     const file=resolve(root,'treeseed.package.yaml');writeFileSync(file,JSON.stringify({development:runtime}));
@@ -23,7 +23,10 @@ test('container startup and cleanup only invoke the protected manager, including
       record=records.get(payload.sessionId)??record;
       if(request.handlerId==='local.dev.environment')return {environment:{}};
       if(request.handlerId==='local.dev.container'){assert.equal(payload.sessionId,selected);actions.push(payload.action);return {};}
-      if(request.handlerId==='local.dev.use')record.session.targets[0].mode=payload.mode;
+      if(request.handlerId==='local.dev.use'){
+        if(payload.mode!=='released')assert.equal(payload.port,3000,'Every activation, including restart, must reattach the canonical route');
+        record.session.targets[0].mode=payload.mode;
+      }
       return record;
     }};
     assert.equal(await runCommandLine(['dev','session','start',file,'--json'],context),0);


### PR DESCRIPTION
## Contract
Refs treeseed-ai/deployment#527. Delegate Docker-backed API target lifecycle to protected local.dev.container instead of spawning operator Docker commands. Restore released routes before restart/stop. Persist manifest and local state per session; explicit --session must never use another session's files. Include secret contracts in the host development runtime closure.

## Verification
Build and targeted development-session tests passed (10 tests); regression test exercises two sessions with explicit use/restart/released/stop and verifies no local Docker spawn. Live API start/restart/released/repeated cleanup passed. After selecting this CLI through managed live development, ordinary trsd dev restart api.service --session succeeded with no sudo or Docker group.

## Release dependencies
Requires Deployment supervisor implementation and SDK #247 lazy encryption import. Current host acceptance uses live development snapshots, not a published RC. Actions and released dependency read-back remain outstanding.