### PR TITLE
chore(release): publish accepted CLI changes as rc63

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.62",
+  "version": "0.13.0-rc.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.62",
+      "version": "0.13.0-rc.63",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.62",
+  "version": "0.13.0-rc.63",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Objective / authority
Complete #145 and the user-authorized Admin #96 release chain. Version-only promotion of already merged #144: SDK rc92, capacity installation configuration and safe development host payload copying.

## Verification
Prior implementation Actions 34079453700 and 34079451024 passed. This exact-head PR must pass Actions before staging merge/tag.

## Rollback
Restore prior exact CLI artifact; no host state or credentials changed by the version bump. No production merge.