### PR TITLE
fix: recover package overlays without partial dependency changes

### DIFF
--- a/src/cli/commands/development-support/overlays.ts
+++ b/src/cli/commands/development-support/overlays.ts
@@ -52,13 +52,24 @@ export function installPackageOverlay(state: OverlaySessionState, record: { sess
 	if (target.kind !== 'package-watch') return;
 	const packageName = (JSON.parse(readFileSync(resolve(worktree, 'package.json'), 'utf8')) as { name?: string }).name;
 	if (!packageName) throw new Error(`${runtime.project.id} package overlay has no package name.`);
-	restoreOverlays(state, runtime.project.id, false);
+	const planned: Array<{ link: string; backup: string; owned: boolean }> = [];
 	for (const consumerId of affectedConsumers(record.runtimes, runtime.project.id, target.id)) {
 		const consumer = record.session.repositories.find((entry) => entry.projectId === consumerId); if (!consumer) continue;
 		const link = resolve(consumer.worktree, 'node_modules', ...packageName.split('/'));
 		const backup = `${link}.treeseed-release-${state.sessionId}`;
+		let owned = false;
+		try { owned = lstatSync(link).isSymbolicLink() && resolve(dirname(link), readlinkSync(link)) === resolve(overlayRoot, 'current'); } catch { /* No existing link. */ }
+		if (existsSync(backup) && !owned) throw new Error(`Stale development overlay backup blocks ${link}.`);
+		planned.push({ link, backup, owned });
+	}
+	// Validate every ownership boundary before changing any consumer. A recovered
+	// exact link is evidence of ownership; a similarly named backup alone is not.
+	for (const { link, backup, owned } of planned) {
+		if (owned) {
+			if (!state.overlays.some(overlay => overlay.link === link)) state.overlays.push({ projectId: runtime.project.id, packageName, link, backup: existsSync(backup) ? backup : null, overlayRoot });
+			continue;
+		}
 		mkdirSync(dirname(link), { recursive: true });
-		if (existsSync(backup)) throw new Error(`Stale development overlay backup blocks ${link}.`);
 		let retained: string | null = null;
 		try { lstatSync(link); renameSync(link, backup); retained = backup; } catch (error) { if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error; }
 		symlinkSync(relativeOverlayTarget(link, overlayRoot), link, 'dir'); state.overlays.push({ projectId: runtime.project.id, packageName, link, backup: retained, overlayRoot });

--- a/tests/unit/command-boundary/recovery/overlay-readoption.test.ts
+++ b/tests/unit/command-boundary/recovery/overlay-readoption.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, symlinkSync, readlinkSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import { installPackageOverlay, restoreOverlays } from '../../../../src/cli/commands/development-support/overlays.ts';
+
+function fixture() {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-overlay-')), source = resolve(root, 'source'), overlay = resolve(root, 'overlay');
+	mkdirSync(source); mkdirSync(resolve(overlay, 'current'), { recursive: true }); writeFileSync(resolve(source, 'package.json'), '{"name":"@test/source"}');
+	const runtime: any = { project: { id: 'source' }, targets: [] }, target: any = { id: 'package', kind: 'package-watch' };
+	const consumers = ['one', 'two'].map(projectId => {
+		const worktree = resolve(root, projectId); mkdirSync(resolve(worktree, 'node_modules/@test/source'), { recursive: true });
+		writeFileSync(resolve(worktree, 'node_modules/@test/source/original'), projectId); return { projectId, worktree };
+	});
+	const record: any = { session: { repositories: consumers }, runtimes: consumers.map(item => ({ project: { id: item.projectId }, targets: [{ id: 'app', dependencies: [{ id: 'source', target: 'package', reaction: 'restart' }] }] })) };
+	const state: any = { sessionId: 'dev-test', processes: {}, overlays: [] };
+	const install = () => installPackageOverlay(state, record, runtime, target, source, overlay);
+	return { root, state, consumers, install, overlay };
+}
+
+test('re-adopts exact links and preserves release originals without nesting backups', () => {
+	const f = fixture(); try {
+		f.install(); const links = f.state.overlays.map((item: any) => ({ ...item })); f.state.overlays = [];
+		f.install(); assert.deepEqual(f.state.overlays, links); f.install(); assert.equal(f.state.overlays.length, 2);
+		restoreOverlays(f.state, 'source', false);
+		for (const item of f.consumers) assert.equal(readFileSync(resolve(item.worktree, 'node_modules/@test/source/original'), 'utf8'), item.projectId);
+	} finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('a later foreign backup conflict does not mutate any earlier consumer', () => {
+	const f = fixture(); try {
+		const second = resolve(f.consumers[1]!.worktree, 'node_modules/@test/source');
+		symlinkSync(f.overlay, `${second}.treeseed-release-dev-test`);
+		assert.throws(f.install, /Stale development overlay backup/);
+		assert.equal(f.state.overlays.length, 0);
+		assert.ok(existsSync(resolve(f.consumers[0]!.worktree, 'node_modules/@test/source/original')));
+		assert.equal(readlinkSync(`${second}.treeseed-release-dev-test`), f.overlay);
+	} finally { rmSync(f.root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Summary
Preflights all consumer backup boundaries before changing dependency links. Re-adopts links only when they resolve to the exact session overlay, retaining original release backups. Avoids the partial restore/relink behavior encountered during managed AI acceptance.

Closes #149

## Verification
Two focused Node tests pass: repeat adoption/restoration and a late foreign backup conflict preserving every earlier consumer. Build and file policy pass. Managed local SDK overlay re-adoption succeeded; the live API again passes database/OpenBao readiness and imports the registration contract.

## Scope and rollback
No source/runtime state deletion; no host purge, bootstrap, or privilege changes. Normal development release restoration retains original dependency backups.