### PR TITLE
release: prepare CLI rc65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.64",
+  "version": "0.13.0-rc.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.64",
+      "version": "0.13.0-rc.65",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.64",
+  "version": "0.13.0-rc.65",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Release preparation for #149 / merged #150. Includes safe exact-overlay re-adoption and preflight of consumer conflicts. Version/lock only; no rebuilt artifact duplication. Required Actions produce the immutable candidate for staging tag publication. Rollback selects the prior CLI component through the manager.