### PR TITLE
feat(platform): allow explicit public project repository creation

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -353,6 +353,7 @@ Execution: `local.platform.project.create`.
 - `--plan`: Return the exact proposed outcome without mutation.
 - `--apply`: Apply the accepted creation plan.
 - `--template <value>`: Published template identity.
+- `--visibility <value>`: Repository visibility: public or private (default private).
 
 ## trsd platform topology
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.67",
+  "version": "0.13.0-rc.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.67",
+      "version": "0.13.0-rc.68",
       "bundleDependencies": [
         "ink",
         "react",
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.99",
+        "@treeseed/sdk": "0.13.0-rc.100",
         "ink": "^7.1.1",
         "react": "^19.2.8",
         "string-width": "^8.2.2",
@@ -4686,9 +4686,9 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.99",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.99.tgz",
-      "integrity": "sha512-73M1gMoSbAhHgNZdsg03gcyKZfingnv8NU+vQGtVetSzjiRFNq+1dNwInidLFU5BHnrZc/04R7dmgM2WrJeG1Q==",
+      "version": "0.13.0-rc.100",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.100.tgz",
+      "integrity": "sha512-fUiCITricTuHTfChv0ygFlNxUvW068HaO3+QYXqjKsyvTBJJVRewGE+xhFG9o5L7r2xqZSVvYd3YskMWcB5IsQ==",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.17",
         "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.67",
+  "version": "0.13.0-rc.68",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -51,7 +51,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.99",
+    "@treeseed/sdk": "0.13.0-rc.100",
     "ink": "^7.1.1",
     "react": "^19.2.8",
     "string-width": "^8.2.2",

--- a/schemas/command-tree.json
+++ b/schemas/command-tree.json
@@ -1085,6 +1085,11 @@
                   "required": true
                 },
                 {
+                  "name": "--visibility",
+                  "description": "Repository visibility: public or private (default private).",
+                  "type": "string"
+                },
+                {
                   "name": "--json",
                   "description": "Emit the stable command-result envelope.",
                   "type": "boolean"

--- a/src/cli/commands/platform/index.ts
+++ b/src/cli/commands/platform/index.ts
@@ -61,6 +61,8 @@ function templateLock(root: string, id: string) {
 async function projectCreate(invocation: ParsedInvocation, context: CommandContext) {
 	const slug = invocation.arguments[0]!;
 	const templateId = String(invocation.options.template ?? '');
+	const visibility = String(invocation.options.visibility ?? 'private');
+	if (visibility !== 'public' && visibility !== 'private') throw invalid('repository_visibility_invalid', '--visibility must be public or private.');
 	if (!templateId) throw invalid('template_required', '--template is required.');
 	const planning = invocation.options.plan === true; const applying = invocation.options.apply === true;
 	if (planning === applying) throw invalid('project_create_mode_required', 'Choose exactly one of --plan or --apply.');
@@ -73,7 +75,7 @@ async function projectCreate(invocation: ParsedInvocation, context: CommandConte
 		invoke = (body) => client.invoke(CONTROL_PLANE_OPERATIONS.projects.create, { path: { teamId }, query: {}, body }, { idempotencyKey: randomUUID(), headers: {} });
 	}
 	if (!teamId) throw Object.assign(new Error('Select an active team with `trsd teams use <team>` before creating a project.'), { category: 'ambiguous_context', code: 'active_team_required' });
-	const plan = projectCreatePlanSchema.parse(payload(await invoke({ mode: 'plan', target: { slug, template, repository: { name: slug, visibility: 'private' } } }, false)));
+	const plan = projectCreatePlanSchema.parse(payload(await invoke({ mode: 'plan', target: { slug, template, repository: { name: slug, visibility } } }, false)));
 	if (planning) return plan;
 	if (!plan.ok) throw Object.assign(new Error('Project creation is blocked by conflicting remote authority.'), { category: 'policy_blocked', code: 'platform_project_create_blocked', partialResult: plan });
 	return payload(await invoke({ mode: 'apply', plan }, true));

--- a/tests/unit/command-boundary/platform/project-create.test.ts
+++ b/tests/unit/command-boundary/platform/project-create.test.ts
@@ -27,6 +27,33 @@ test('platform project create plans through API authority without mutation', asy
 		assert.equal(exit, 0, output.join('\n')); assert.equal(calls.length, 1); assert.equal(calls[0].input.body.mode, 'plan');
 		assert.match(calls[0].options.idempotencyKey, /^[0-9a-f-]{36}$/u);
 		assert.equal(JSON.parse(output[0]!).result.planDigest, digest);
+		assert.equal(calls[0].input.body.target.repository.visibility, 'private');
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('explicit public visibility is preserved in planning and exact apply', async () => {
+	const root = fixture(); const calls: any[] = []; const output: string[] = [];
+	const publicPlan = { ...plan, repository: { ...plan.repository, visibility: 'public' } };
+	try {
+		const exit = await runCommandLine(['platform', 'project', 'create', 'example-app', '--template', 'engineering', '--visibility', 'public', '--apply', '--yes', '--json'], {
+			cwd: root, env: { TREESEED_TEAM_ID: 'team-1' }, interactiveUi: false, write: (value) => output.push(value),
+			operationInvoke: async (_operationId, input: any) => { calls.push(input.body); return { data: input.body.mode === 'plan' ? publicPlan : { ...publicPlan, projectId: 'project-1' } }; },
+		});
+		assert.equal(exit, 0, output.join('\n'));
+		assert.equal(calls[0].target.repository.visibility, 'public');
+		assert.deepEqual(calls[1].plan, publicPlan);
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('invalid visibility fails before invoking project authority', async () => {
+	const root = fixture(); let called = false; const output: string[] = [];
+	try {
+		const exit = await runCommandLine(['platform', 'project', 'create', 'example-app', '--template', 'engineering', '--visibility', 'internal', '--plan', '--json'], {
+			cwd: root, env: { TREESEED_TEAM_ID: 'team-1' }, interactiveUi: false, write: (value) => output.push(value),
+			operationInvoke: async () => { called = true; return { data: plan }; },
+		});
+		assert.equal(exit, 1); assert.equal(called, false);
+		assert.match(output.join(''), /repository_visibility_invalid/u);
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
 


### PR DESCRIPTION
Addresses #159; prerequisite for treeseed-ai/platform#467.

Adds --visibility public|private with private default, validates before any API operation and passes visibility into the exact managed project plan. Consumes published SDK rc100; regenerates public command docs/schema; prepares CLI rc68.

Four focused tests pass (default private, explicit public plan/apply, invalid value zero invocations, exact apply); package build and architecture checks pass. Required Actions must pass. No existing repository visibility changes and no live identity/authentication changes.

Keep #159 open until managed public project creation read-back passes.