### PR TITLE
feat(identity): integrate CLI browser and device sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ trsd workdays list --team treeseed --json
 
 Commands default to the local control plane at `http://127.0.0.1:3002`. `TREESEED_API_BASE_URL` overrides that address. Server profiles and encrypted OAuth sessions are owned locally by the CLI; control-plane behavior remains API-owned.
 
+Identity sign-in requires the API's trusted HTTPS address (the managed local edge is
+`https://api.treeseed.localhost`), not its internal HTTP listener. Configure that address
+in the server profile or `TREESEED_API_BASE_URL`. `trsd auth login` discovers the API's
+advertised identity provider and uses browser PKCE with a temporary loopback callback.
+Use `--device` on a headless machine; use `--issuer` only to select among authorities
+advertised by that API. The CLI never collects the identity-provider password.
+
+Tokens stay in OS-encrypted local custody, bound to the exact API, issuer, subject,
+and client. Refresh, logout, and team selection serialize through one OS transaction.
+Old unbound sessions require fresh sign-in, not a fallback to the retired token issuer.
+`trsd auth logout` removes the local session even if upstream revocation is unavailable;
+the JSON result reports whether upstream revocation succeeded.
+
 ## Team discussions
 
 `trsd send` opens the active team's topic browser; `trsd send <topic>` opens it with a topic selected. The workbench keeps per-topic composers and recipient selections, shows all listeners and lifecycle events, and can export the visible transcript to Markdown. `trsd send <topic> <message>` remains the one-shot form.

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -127,12 +127,14 @@ Auth operations.
 Login the selected resource.
 
 Operation: mutation. Result schema: `treeseed.command.login/v1`.
-Execution: `protocol.oauth.device.login`.
+Execution: `protocol.identity.login`.
 
 - `--server <value>`: Control-plane server profile or URL.
 - `--json`: Emit the stable JSON envelope.
 - `--plan`: Return the exact proposed outcome without mutation.
-- `--timeout <value>`: Maximum seconds to wait for device authorization.
+- `--timeout <value>`: Maximum seconds to wait for identity authorization.
+- `--device`: Use headless device authorization instead of local browser PKCE.
+- `--issuer <value>`: Choose an authorization server advertised by the selected API.
 
 ### trsd auth logout
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/sdk": "0.13.0-rc.100",
+        "@treeseed/identity": "0.1.0-rc.9",
+        "@treeseed/sdk": "0.13.0-rc.106",
         "ink": "^7.1.1",
         "react": "^19.2.8",
         "string-width": "^8.2.2",
@@ -30,6 +31,7 @@
         "@types/node": "^24.6.0",
         "@types/react": "^19.2.14",
         "esbuild": "^0.25.10",
+        "jose": "6.2.12",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
       },
@@ -4714,10 +4716,499 @@
         "@esbuild/win32-x64": "0.28.2"
       }
     },
+    "node_modules/@treeseed/identity": {
+      "version": "0.1.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@treeseed/identity/-/identity-0.1.0-rc.9.tgz",
+      "integrity": "sha512-Gx9md7npq/vvxR/V9U9GvY7VOX66v9KKiAuywqHT1N+RQi3l0EpCuIq5cPwOHWFdQ6qEq8cF2lsAm5anrNK7lA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@treeseed/sdk": "0.13.0-rc.105",
+        "jose": "6.2.12",
+        "oauth4webapi": "3.8.8"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/@treeseed/sdk": {
+      "version": "0.13.0-rc.105",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.105.tgz",
+      "integrity": "sha512-JuZi/k/c84qfQlV9TDflbAiLSoI17pYlrmp/RRylJt2vlzhhfSK+eZgAKk/aZuWKWqIbXPghx3qfvrpl8fubFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@treeseed/treedx": "0.3.0-rc.17",
+        "esbuild": "^0.28.0",
+        "libsodium-wrappers-sumo": "0.8.4",
+        "typescript": "^5.9.3",
+        "yaml": "^2.8.1",
+        "zod": "^3.25.76"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@treeseed/identity/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.100",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.100.tgz",
-      "integrity": "sha512-fUiCITricTuHTfChv0ygFlNxUvW068HaO3+QYXqjKsyvTBJJVRewGE+xhFG9o5L7r2xqZSVvYd3YskMWcB5IsQ==",
+      "version": "0.13.0-rc.106",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.106.tgz",
+      "integrity": "sha512-x/X0wZxBC7LN3PV8YoJoSl/MW6vQJzSG4/49oaJ9MzwnStnH0s2aSBxLgCXm87DbtEo9H9xgVLVX4vM7cbXzFA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.17",
         "esbuild": "^0.28.0",
@@ -7827,6 +8318,15 @@
         "url": "https://github.com/sponsors/dmonad"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9880,6 +10380,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.8",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.8.tgz",
+      "integrity": "sha512-8N28E+a/oxfXWBgOMt+ZP/JUf/XR+IFbvkAEPP3gznXOMv9BpAAwiIj0TFNz3tGTPc0ZQ8zmWBNgN1nAys0gng==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/object-assign": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.68",
+  "version": "0.13.0-rc.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.68",
+      "version": "0.13.0-rc.69",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.68",
+  "version": "0.13.0-rc.69",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/sdk": "0.13.0-rc.100",
+    "@treeseed/sdk": "0.13.0-rc.106",
+    "@treeseed/identity": "0.1.0-rc.9",
     "ink": "^7.1.1",
     "react": "^19.2.8",
     "string-width": "^8.2.2",
@@ -64,6 +65,7 @@
     "yaml"
   ],
   "devDependencies": {
+    "jose": "6.2.12",
     "@treeseed/deployment": "https://github.com/treeseed-ai/deployment/releases/download/0.1.0-rc.277/treeseed-deployment-runtime-0.1.0-rc.277.tgz",
     "@treeseed/ui": ">=0.12.18-rc.12 <0.14.0",
     "@types/node": "^24.6.0",

--- a/schemas/command-tree.json
+++ b/schemas/command-tree.json
@@ -514,8 +514,18 @@
             },
             {
               "name": "--timeout",
-              "description": "Maximum seconds to wait for device authorization.",
+              "description": "Maximum seconds to wait for identity authorization.",
               "type": "number"
+            },
+            {
+              "name": "--device",
+              "description": "Use headless device authorization instead of local browser PKCE.",
+              "type": "boolean"
+            },
+            {
+              "name": "--issuer",
+              "description": "Choose an authorization server advertised by the selected API.",
+              "type": "string"
             }
           ],
           "authorization": {
@@ -525,7 +535,7 @@
           "resultSchemaId": "treeseed.command.login/v1",
           "execution": {
             "kind": "protocol",
-            "handlerId": "protocol.oauth.device.login"
+            "handlerId": "protocol.identity.login"
           }
         },
         {

--- a/scripts/packages/release-verify.ts
+++ b/scripts/packages/release-verify.ts
@@ -216,7 +216,7 @@ function assertPackageDependencyShape() {
 		dependencies?: Record<string, string>;
 	};
 	const dependencyNames = Object.keys(packageJson.dependencies ?? {}).sort();
-	const expectedDependencies = ['@treeseed/sdk', 'ink', 'react', 'string-width', 'yaml'];
+	const expectedDependencies = ['@treeseed/identity', '@treeseed/sdk', 'ink', 'react', 'string-width', 'yaml'];
 	if (dependencyNames.join(',') !== expectedDependencies.join(',')) {
 		throw new Error(`CLI runtime dependencies must be exactly ${expectedDependencies.join(', ')}. Found: ${dependencyNames.join(', ') || '(none)'}`);
 	}

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -1,85 +1,53 @@
-import { setTimeout as delay } from 'node:timers/promises';
-import type { OAuthScope } from '@treeseed/sdk/operator-contracts';
-import { ControlPlaneClient, ControlPlaneClientError } from '@treeseed/sdk/control-plane-client';
+import { ControlPlaneClient } from '@treeseed/sdk/control-plane-client';
 import { CONTROL_PLANE_OPERATIONS } from '@treeseed/sdk/operator-contracts';
 import type { CommandContext, ParsedInvocation } from '../types.js';
-import { CONTROL_PLANE_CLI_CLIENT_ID, createControlPlaneClient } from '../support/client.js';
+import { createControlPlaneClient } from '../support/client.js';
 import { updateServerSession, saveServerProfile, saveServerSession } from '../support/server-custody.js';
-
-const DEFAULT_SCOPES: OAuthScope[] = ['treeseed:read', 'treeseed:knowledge:write', 'treeseed:governance:write', 'treeseed:projects:write', 'treeseed:execution'];
-const DEFAULT_LOGIN_TIMEOUT_SECONDS = 300;
-
-function configuredLoginTimeoutSeconds(invocation: ParsedInvocation, context: CommandContext) {
-	const configured = invocation.options.timeout ?? context.env.TREESEED_CLI_LOGIN_TIMEOUT_SECONDS
-		?? context.env.TREESEED_CLI_OPERATION_TIMEOUT_SECONDS ?? DEFAULT_LOGIN_TIMEOUT_SECONDS;
-	const value = Number(configured);
-	if (!Number.isFinite(value) || value <= 0 || value > 3_600) throw Object.assign(new Error('--timeout must be between 1 and 3600 seconds.'), { category: 'invalid_input', code: 'invalid_timeout' });
-	return value;
-}
-
-function pollingState(error: unknown) {
-	if (!(error instanceof ControlPlaneClientError)) return 'failed' as const;
-	if (error.problem.code === 'slow_down') return 'slow_down' as const;
-	if (error.problem.code === 'authorization_pending' || /authorization.pending/iu.test(error.message)) return 'pending' as const;
-	return 'failed' as const;
-}
+import { identityLogin, IDENTITY_CLIENT_ID, IDENTITY_SCOPES } from '../support/identity-login.js';
+import { identitySessionClient } from '../support/identity-session.js';
 
 function record(value: unknown): Record<string, unknown> { return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}; }
-function principalIdentity(value: unknown) { const principal = record(value); return String(principal.id ?? principal.email ?? principal.username ?? ''); }
 function teamsFrom(value: unknown) {
 	const source = record(value); const values = Array.isArray(source.teams) ? source.teams : Array.isArray(source.items) ? source.items : [];
-	return values.map(record).flatMap((team) => {
-		const id = String(team.id ?? '').trim(); const slug = String(team.slug ?? '').trim(); const name = String(team.name ?? team.displayName ?? slug).trim();
-		return id && slug ? [{ id, slug, name }] : [];
+	return values.map(record).flatMap(team => {
+		const id = String(team.id ?? '').trim(), slug = String(team.slug ?? '').trim(), name = String(team.name ?? team.displayName ?? slug).trim();
+		return id && slug ? [{id,slug,name}] : [];
 	});
 }
 
 export async function runAuth(invocation: ParsedInvocation, context: CommandContext) {
-	const { profile, session, client } = await createControlPlaneClient(invocation, context, false);
+	const {profile, session} = await createControlPlaneClient(invocation, context, false);
 	if (invocation.command.name === 'auth login') {
-		const configuredTimeout = configuredLoginTimeoutSeconds(invocation, context);
-		const authorization = await client.authorizeDevice(CONTROL_PLANE_CLI_CLIENT_ID, DEFAULT_SCOPES, AbortSignal.timeout(configuredTimeout * 1_000));
-		const verificationUrl = authorization.verificationUriComplete ?? authorization.verificationUri;
-		const opened = await Promise.resolve(context.openExternal?.(verificationUrl)).catch(() => false) ?? false;
-		if (opened) context.write('Opened your default browser. Follow the instructions there.', 'stderr');
-		else context.write('A browser could not be opened automatically.', 'stderr');
-		const codeFallback = authorization.verificationUriComplete ? '' : ` and enter code ${authorization.userCode}`;
-		context.write(`To authorize from this or another computer, open ${verificationUrl}${codeFallback}.`, 'stderr');
-		const timeoutSeconds = Math.min(configuredTimeout, authorization.expiresIn);
-		const deadline = Date.now() + timeoutSeconds * 1_000;
-		let interval = Math.max(1, authorization.interval) * 1_000;
-		while (Date.now() < deadline) {
-			try {
-				const token = await client.exchangeDeviceCode(CONTROL_PLANE_CLI_CLIENT_ID, authorization.deviceCode);
-				const expiresAt = new Date(Date.now() + token.expiresIn * 1_000).toISOString();
-				const authenticatedClient = new ControlPlaneClient({ profile, accessToken: token.accessToken, userAgent: 'trsd' });
-				const current = await authenticatedClient.invoke(CONTROL_PLANE_OPERATIONS.accounts.current, { path: {}, query: {}, body: undefined });
-				const principal = current.data && typeof current.data === 'object' && 'principal' in current.data
-					? current.data.principal as typeof token.principal : token.principal;
-				const teams = teamsFrom(current.data);
-				const prior = session?.activeTeam;
-				const samePrincipal = principalIdentity(session?.principal) && principalIdentity(session?.principal) === principalIdentity(principal);
-				const activeTeam = samePrincipal && prior && teams.some((team) => team.id === prior.id)
-					? teams.find((team) => team.id === prior.id)! : teams.length === 1 ? teams[0]! : null;
-				saveServerProfile(profile, context.env);
-				await saveServerSession({ serverId: profile.serverId, audience: token.audience, accessToken: token.accessToken, refreshToken: token.refreshToken, expiresAt, principal, activeTeam }, context.env);
-				return { serverId: profile.serverId, principal: principal ?? null, activeTeam, expiresAt, scopes: token.scope };
-			} catch (error) {
-				const state = pollingState(error);
-				if (state === 'failed') throw error;
-				if (state === 'slow_down') interval += 5_000;
-				await delay(Math.min(interval, Math.max(1, deadline - Date.now())));
-			}
-		}
-		throw Object.assign(new Error(`Device authorization was not approved within ${timeoutSeconds} seconds.`), { category: 'authentication_required', code: 'device_authorization_timeout' });
+		const timeoutSeconds = Number(invocation.options.timeout ?? context.env.TREESEED_CLI_LOGIN_TIMEOUT_SECONDS ?? 300);
+		if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0 || timeoutSeconds > 3600) throw new Error('--timeout must be between 1 and 3600 seconds.');
+		const result = await identityLogin({resource:profile.baseUrl, issuer:typeof invocation.options.issuer === 'string' ? invocation.options.issuer : undefined,
+			device:invocation.options.device === true, timeoutSeconds}, context);
+		const client = new ControlPlaneClient({profile,accessToken:result.tokens.access_token,userAgent:'trsd'});
+		const current = await client.invoke(CONTROL_PLANE_OPERATIONS.accounts.current, {path:{},query:{},body:undefined});
+		const principal = record(current.data).principal;
+		if (!principal || typeof principal !== 'object' || !('id' in principal) || typeof principal.id !== 'string') throw new Error('The API has no local principal mapping for this identity.');
+		const teams = teamsFrom(current.data), prior = session?.activeTeam;
+		const sameIdentity = session?.identity?.issuer === result.principal.identity.issuer && session?.identity?.subject === result.principal.identity.subject;
+		const activeTeam = sameIdentity && prior && teams.some(team => team.id === prior.id) ? teams.find(team => team.id === prior.id)! : teams.length === 1 ? teams[0]! : null;
+		if (!Number.isFinite(result.tokens.expires_in) || result.tokens.expires_in! <= 0) throw new Error('Identity did not return a bounded access-token lifetime.');
+		const expiresAt = new Date(Date.now() + result.tokens.expires_in! * 1000).toISOString();
+		saveServerProfile(profile, context.env);
+		await saveServerSession({serverId:profile.serverId, audience:result.resource, identity:result.principal.identity, clientId:IDENTITY_CLIENT_ID,
+			scopes:IDENTITY_SCOPES, accessToken:result.tokens.access_token, refreshToken:result.tokens.refresh_token, expiresAt,
+			principal:principal as NonNullable<typeof session>['principal'], activeTeam}, context.env);
+		return {serverId:profile.serverId, principal, identity:result.principal.identity, activeTeam, expiresAt, scopes:IDENTITY_SCOPES};
 	}
 	if (invocation.command.name === 'auth logout') {
-		await updateServerSession(profile.serverId, context.env, async current => {
+		let upstreamRevoked = false;
+		await updateServerSession(profile.serverId,context.env,async current => {
 			const token = current?.refreshToken ?? current?.accessToken;
-			if (token) await client.revokeToken(CONTROL_PLANE_CLI_CLIENT_ID, token, AbortSignal.timeout(10_000)).catch(() => undefined);
+			if (current && token) {
+				try { await (await identitySessionClient(profile,current)).revoke(token); upstreamRevoked = true; }
+				catch { /* Local logout must still succeed; never retry ambiguous revocation. */ }
+			}
 			return null;
 		});
-		return { serverId: profile.serverId, loggedOut: true };
+		return {serverId:profile.serverId,loggedOut:true,upstreamRevoked};
 	}
-	throw new Error(`Unknown OAuth protocol command: ${invocation.command.name}`);
+	throw new Error(`Unknown identity command: ${invocation.command.name}`);
 }

--- a/src/cli/commands/services/credentials.ts
+++ b/src/cli/commands/services/credentials.ts
@@ -35,7 +35,7 @@ export async function runServiceCredentials(invocation:ParsedInvocation,context:
       if(!context.promptSecret&&!context.interactiveUi)throw invalid();
       const connection=data(await invoke(operations.connection,{path:{teamId,connectionId:path.connectionId},query:{},body:undefined}));
       const profile=getServiceProviderDefinition(connection.providerId)?.credentialProfiles.find(p=>p.id===path.profileId);
-      if(!profile?.authoritySchemes.includes('openbao'))throw invalid();
+      if(!profile?.authoritySchemes?.includes('openbao'))throw invalid();
       for(const field of profile.fields.filter(f=>f.sensitive)) {
         const value=String(await (context.promptSecret ?? promptHidden)(`${field.label}${field.required?'':' (optional)'}: `));
         if(value)values[field.key]=value;

--- a/src/cli/support/client.ts
+++ b/src/cli/support/client.ts
@@ -6,8 +6,7 @@ import {
 } from '@treeseed/sdk/control-plane-client';
 import type { CommandContext, ParsedInvocation } from '../types.js';
 import { loadServerRegistry, loadServerSession, updateServerSession } from './server-custody.js';
-
-export const CONTROL_PLANE_CLI_CLIENT_ID = 'trsd';
+import { identitySessionClient, validateIdentitySession } from './identity-session.js';
 
 export function controlPlaneServerRegistry(context: Pick<CommandContext, 'env'>): ControlPlaneServerRegistry {
 	const stored = loadServerRegistry(context.env);
@@ -28,17 +27,19 @@ export async function createControlPlaneClient(invocation: Pick<ParsedInvocation
 	const profile = resolveControlPlaneServer(selector, registry);
 	let session = loadServerSession(profile.serverId, context.env);
 	if (requireAuth && !session?.accessToken) throw Object.assign(new Error(`Not logged in to ${profile.serverId}. Run trsd auth login --server ${profile.serverId}.`), { category: 'authentication_required', code: 'authentication_required' });
+	if (requireAuth && session) validateIdentitySession(profile, session);
 	let client = new ControlPlaneClient({ profile, accessToken: session?.accessToken ?? null, userAgent: 'trsd' });
 	if (requireAuth && session?.refreshToken && (forceRefresh || (session.expiresAt && new Date(session.expiresAt).getTime() <= Date.now() + 30_000))) {
 		const observedRefresh = session.refreshToken;
 		session = await updateServerSession(profile.serverId, context.env, async current => {
 			if (!current?.accessToken || !current.refreshToken) throw Object.assign(new Error('Session ended before renewal. Log in again.'), { category: 'authentication_required', code: 'authentication_required' });
+			validateIdentitySession(profile,current);
 			const expired = current.expiresAt && new Date(current.expiresAt).getTime() <= Date.now() + 30_000;
 			if (!expired && (!forceRefresh || current.refreshToken !== observedRefresh)) return current;
-			const refreshingClient = new ControlPlaneClient({ profile, accessToken: current.accessToken, userAgent: 'trsd' });
-			const token = await refreshingClient.refreshAccessToken(CONTROL_PLANE_CLI_CLIENT_ID, current.refreshToken, AbortSignal.timeout(10_000));
-			if (token.audience !== current.audience) throw Object.assign(new Error('Refreshed token audience does not match the stored server session.'), { category: 'authentication_required', code: 'oauth_audience_mismatch' });
-			return { serverId: profile.serverId, audience: token.audience, accessToken: token.accessToken, refreshToken: token.refreshToken ?? current.refreshToken, expiresAt: new Date(Date.now() + token.expiresIn * 1_000).toISOString(), principal: token.principal, activeTeam: current.activeTeam ?? null };
+			const result = await (await identitySessionClient(profile,current)).refresh(current.refreshToken,current.identity);
+			if (!Number.isFinite(result.tokens.expires_in) || result.tokens.expires_in! <= 0) throw new Error('Identity did not return a bounded token lifetime.');
+			return { ...current, accessToken:result.tokens.access_token, refreshToken:result.tokens.refresh_token ?? current.refreshToken,
+				expiresAt:new Date(Date.now() + result.tokens.expires_in! * 1000).toISOString() };
 		}, true);
 		if (!session) throw new Error('Session ended during renewal. Log in again.');
 		client = new ControlPlaneClient({ profile, accessToken: session.accessToken, userAgent: 'trsd' });

--- a/src/cli/support/identity-login.ts
+++ b/src/cli/support/identity-login.ts
@@ -1,0 +1,69 @@
+import { createServer } from 'node:http';
+import { setTimeout as delay } from 'node:timers/promises';
+import { createDeviceAuthorizationClient, createNativeOidcClient, discoverResourceAuthorization, discoverSigningKeys, type NativeOidcOptions } from '@treeseed/identity';
+import type { CommandContext } from '../types.js';
+
+export const IDENTITY_CLIENT_ID = 'trsd';
+export const IDENTITY_SCOPES = ['treeseed:read', 'treeseed:knowledge:write', 'treeseed:governance:write', 'treeseed:projects:write', 'treeseed:execution'];
+type LoginResult = Awaited<ReturnType<Awaited<ReturnType<Awaited<ReturnType<typeof createNativeOidcClient>>['begin']>>['finish']>>;
+
+async function showAuthorization(url: string, context: CommandContext) {
+	const opened = await Promise.resolve(context.openExternal?.(url)).catch(() => false);
+	context.write(opened ? 'Opened your browser for sign-in.' : `Open this address to sign in: ${url}`, 'stderr');
+}
+
+async function nativeLogin(options: Omit<NativeOidcOptions, 'redirectUri'>, context: CommandContext, timeoutSeconds: number): Promise<LoginResult> {
+	let pending: Awaited<ReturnType<Awaited<ReturnType<typeof createNativeOidcClient>>['begin']>> | undefined;
+	let receive: (result: LoginResult | null) => void = () => {};
+	let redirectUri = '';
+	const server = createServer(async (request, response) => {
+		response.setHeader('cache-control','no-store');
+		response.setHeader('content-type','text/plain; charset=utf-8');
+		try {
+			if (!pending || request.method !== 'GET' || request.headers.host !== new URL(redirectUri).host) throw new Error();
+			const result = await pending.finish(new URL(request.url ?? '/', redirectUri));
+			response.end('Signed in. You can close this window.'); receive(result);
+		} catch { response.writeHead(400); response.end('Invalid sign-in callback. Return to the CLI.'); }
+	});
+	server.requestTimeout = 10000; server.headersTimeout = 10000;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await new Promise<void>((resolve, reject) => { server.once('error',reject); server.listen(0,'127.0.0.1',resolve); });
+		const address = server.address(); if (!address || typeof address === 'string') throw new Error('Local sign-in listener unavailable. Use --device.');
+		redirectUri = `http://127.0.0.1:${address.port}/callback`;
+		pending = await (await createNativeOidcClient({...options, redirectUri})).begin();
+		const completed = new Promise<LoginResult | null>(resolve => {
+			receive = resolve; timer = setTimeout(() => resolve(null), Math.min(timeoutSeconds * 1000, pending!.expiresAt - Date.now()));
+		});
+		await showAuthorization(pending.authorizationUrl, context);
+		const result = await completed;
+		if (!result) throw new Error('Sign-in timed out. Retry, or use --device for a headless session.');
+		return result;
+	} finally {
+		if (timer) clearTimeout(timer); pending?.cancel();
+		server.closeAllConnections();
+		await new Promise<void>(resolve => server.close(() => resolve()));
+	}
+}
+
+export async function identityLogin(input: {resource:string; issuer?:string; device:boolean; timeoutSeconds:number}, context:CommandContext): Promise<LoginResult> {
+	const selected = await discoverResourceAuthorization({resource:input.resource, issuer:input.issuer, transport:fetch});
+	if (IDENTITY_SCOPES.some(scope => !selected.scopesSupported.includes(scope))) throw new Error('The selected API does not advertise the required TreeSeed login scopes.');
+	const options = {issuer:selected.issuer, clientId:IDENTITY_CLIENT_ID, resource:selected.resource, scopes:IDENTITY_SCOPES,
+		verificationKey:await discoverSigningKeys({issuer:selected.issuer, transport:fetch}), profile:'keycloak' as const, transport:fetch,
+		resolvePrincipal:async (identity: {subject:string}) => ({principalId:identity.subject,kind:'human' as const})};
+	if (!input.device) return nativeLogin(options, context, input.timeoutSeconds);
+	const pending = await (await createDeviceAuthorizationClient({...options, resources:[selected.resource]})).begin({resource:selected.resource, scopes:IDENTITY_SCOPES});
+	try {
+		await showAuthorization(pending.verificationUriComplete ?? pending.verificationUri, context);
+		if (!pending.verificationUriComplete) context.write(`Enter code ${pending.userCode}.`,'stderr');
+		const deadline = Math.min(pending.expiresAt, Date.now() + input.timeoutSeconds * 1000);
+		while (Date.now() < deadline) {
+			const result = await pending.poll();
+			if (result.status === 'authorized') return result;
+			if (result.status !== 'pending') throw new Error(`Identity sign-in ${result.status}. Start a new login.`);
+			await delay(Math.min(Math.max(1,result.nextPollAt - Date.now()), Math.max(1,deadline - Date.now())));
+		}
+		throw new Error('Identity sign-in timed out. Start a new login.');
+	} finally { pending.cancel(); }
+}

--- a/src/cli/support/identity-session.ts
+++ b/src/cli/support/identity-session.ts
@@ -1,0 +1,21 @@
+import { createPublicSessionClient, discoverResourceAuthorization, discoverSigningKeys } from '@treeseed/identity';
+import { publicClientSessionBindingSchema } from '@treeseed/sdk/identity';
+import type { ControlPlaneServerProfile, ControlPlaneServerSession } from '@treeseed/sdk/control-plane-client';
+import { IDENTITY_CLIENT_ID } from './identity-login.js';
+
+export function validateIdentitySession(profile:ControlPlaneServerProfile, session:ControlPlaneServerSession) {
+	const binding = publicClientSessionBindingSchema.safeParse({identity:session.identity,clientId:session.clientId,scopes:session.scopes});
+	if (!binding.success || session.clientId !== IDENTITY_CLIENT_ID || session.audience !== profile.baseUrl) {
+		throw Object.assign(new Error(`Identity sign-in required for ${profile.serverId}. Run trsd auth login --server ${profile.serverId}.`), {category:'authentication_required',code:'identity_login_required'});
+	}
+	return binding.data;
+}
+
+export async function identitySessionClient(profile:ControlPlaneServerProfile, session:ControlPlaneServerSession) {
+	const binding = validateIdentitySession(profile,session);
+	await discoverResourceAuthorization({resource:session.audience,issuer:binding.identity.issuer,transport:fetch});
+	return createPublicSessionClient({issuer:binding.identity.issuer,clientId:binding.clientId,resource:session.audience,scopes:binding.scopes,
+		profile:'keycloak',transport:fetch,verificationKey:await discoverSigningKeys({issuer:binding.identity.issuer,transport:fetch}),
+		resolvePrincipal:async identity => identity.issuer === binding.identity.issuer && identity.subject === binding.identity.subject
+			? {principalId:session.principal?.id ?? identity.subject,kind:'human'} : null});
+}

--- a/tests/contract/package/thin-package.test.ts
+++ b/tests/contract/package/thin-package.test.ts
@@ -9,7 +9,8 @@ test('package has one executable and only its declared CLI runtime dependencies'
 	assert.equal(pkg.types, undefined);
 	assert.equal(pkg.files.some((path: string) => path.startsWith('scripts/')), false);
 	assert.equal(pkg.dependencies['@treeseed/agent'], undefined);
-	assert.deepEqual(Object.keys(pkg.dependencies).sort(), ['@treeseed/sdk','ink','react','string-width','yaml']);
+	assert.deepEqual(Object.keys(pkg.dependencies).sort(), ['@treeseed/identity','@treeseed/sdk','ink','react','string-width','yaml']);
+	assert.match(pkg.dependencies['@treeseed/identity'], /^0\.1\.0-rc\.\d+$/);
 	assert.match(pkg.dependencies['@treeseed/sdk'], /^0\.13\.0-rc\.\d+$/);
 	assert.match(pkg.devDependencies['@treeseed/deployment'], /^https:\/\/github\.com\/treeseed-ai\/deployment\/releases\/download\/0\.1\.0-rc\.\d+\/treeseed-deployment-runtime-0\.1\.0-rc\.\d+\.tgz$/);
 	assert.equal(pkg.devDependencies['@treeseed/ui'], '>=0.12.18-rc.12 <0.14.0');

--- a/tests/support/identity-fixture.ts
+++ b/tests/support/identity-fixture.ts
@@ -1,0 +1,40 @@
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+import { IDENTITY_SCOPES } from '../../src/cli/support/identity-login.ts';
+
+export const identityIssuer = 'https://identity.example.test/realms/local';
+export const apiResource = 'https://api.example.test';
+export const sessionBinding = {identity:{issuer:identityIssuer,subject:'subject'},clientId:'trsd',scopes:IDENTITY_SCOPES};
+
+export async function identityFixture() {
+	const keys = await generateKeyPair('RS256');
+	const jwk = {...await exportJWK(keys.publicKey),kid:'fixture'};
+	let nonce = '';
+	const state = {tokenCalls:0,rejectRenewal:false,subject:'subject',audience:apiResource};
+	const transport: typeof fetch = async (input,init) => {
+		const url = String(input);
+		if (url === `${apiResource}/.well-known/oauth-protected-resource`) return Response.json({resource:apiResource,authorization_servers:[identityIssuer],scopes_supported:IDENTITY_SCOPES});
+		if (url === `${identityIssuer}/.well-known/openid-configuration`) return Response.json({issuer:identityIssuer,jwks_uri:`${identityIssuer}/certs`,authorization_endpoint:`${identityIssuer}/authorize`,
+			token_endpoint:`${identityIssuer}/token`,revocation_endpoint:`${identityIssuer}/revoke`,device_authorization_endpoint:`${identityIssuer}/device`,code_challenge_methods_supported:['S256']});
+		if (url === `${identityIssuer}/certs`) return Response.json({keys:[jwk]});
+		if (url === `${identityIssuer}/device`) return Response.json({device_code:'private-device',user_code:'USER-CODE',verification_uri:`${identityIssuer}/approve`,expires_in:60,interval:1});
+		if (url === `${identityIssuer}/revoke`) return new Response(null,{status:200});
+		if (url === `${identityIssuer}/token`) {
+			state.tokenCalls++;
+			const body = new URLSearchParams(String(init?.body));
+			if (state.rejectRenewal && body.get('grant_type') === 'refresh_token') return Response.json({error:'temporarily_unavailable'},{status:503});
+			const now = Math.floor(Date.now()/1000);
+			const sign = (claims:Record<string,unknown>) => new SignJWT({iss:identityIssuer,sub:state.subject,iat:now,exp:now+300,...claims}).setProtectedHeader({alg:'RS256',kid:'fixture'}).sign(keys.privateKey);
+			const access_token = await sign({aud:state.audience,typ:'Bearer',azp:'trsd',scope:IDENTITY_SCOPES.join(' ')});
+			return Response.json({access_token,refresh_token:'rotated',token_type:'Bearer',expires_in:300,scope:IDENTITY_SCOPES.join(' '),
+				...(body.get('grant_type') === 'authorization_code' ? {id_token:await sign({aud:'trsd',nonce})} : {})});
+		}
+		if (url === `${apiResource}/v1/me`) return Response.json({data:{principal:{id:'local-user',displayName:'Test User'},teams:[]}});
+		throw new Error(`Unexpected synthetic identity request: ${new URL(url).pathname}`);
+	};
+	return {state,transport,authorize(url:string) {
+		const request = new URL(url); nonce = request.searchParams.get('nonce')!;
+		const callback = new URL(request.searchParams.get('redirect_uri')!);
+		callback.searchParams.set('code','synthetic-code'); callback.searchParams.set('state',request.searchParams.get('state')!);
+		return callback;
+	}};
+}

--- a/tests/unit/command-boundary/auth/identity-login.test.ts
+++ b/tests/unit/command-boundary/auth/identity-login.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { runCommandLine } from '../../../../src/cli/runtime.ts';
+import { loadServerSession, saveServerProfile } from '../../../../src/cli/support/server-custody.ts';
+import { apiResource, identityFixture, identityIssuer } from '../../../support/identity-fixture.ts';
+
+for (const device of [false,true]) test(`identity ${device ? 'device':'browser PKCE'} login stores only encrypted resource-bound credentials`,async context=>{
+	const fixture=await identityFixture(), realFetch=globalThis.fetch;
+	context.mock.method(globalThis,'fetch',fixture.transport);
+	const root=mkdtempSync(join(tmpdir(),'treeseed-cli-login-')),env={TREESEED_CONFIG_HOME:root};
+	const output:Array<{value:string;stream?:string}>=[];
+	try {
+		saveServerProfile({serverId:'test',label:'Test',baseUrl:apiResource},env);
+		const exit=await runCommandLine(['auth','login','--server','test','--json',...(device ? ['--device']:[])],{
+			env,interactiveUi:false,write:(value,stream)=>output.push({value,stream}),
+			openExternal:async url=>{
+				if (!device) {const callback=fixture.authorize(url);const response=await realFetch(callback);assert.equal(response.status,200);}
+				return true;
+			},
+		});
+		assert.equal(exit,0,JSON.stringify(output));
+		const session=loadServerSession('test',env)!;
+		assert.deepEqual(session.identity,{issuer:identityIssuer,subject:'subject'});
+		assert.equal(session.principal?.id,'local-user');assert.equal(session.audience,apiResource);
+		const stdout=output.filter(item=>item.stream!=='stderr').map(item=>item.value).join('');
+		assert.equal(JSON.parse(stdout).ok,true);
+		for (const secret of [session.accessToken,session.refreshToken!,'private-device']) assert.equal(JSON.stringify(output).includes(secret),false);
+		assert.match(output.filter(item=>item.stream==='stderr').map(item=>item.value).join(''),/Opened your browser/);
+		output.length=0;
+		assert.equal(await runCommandLine(['auth','logout','--server','test','--json'],{env,interactiveUi:false,write:(value,stream)=>output.push({value,stream})}),0);
+		assert.equal(loadServerSession('test',env),null);
+		assert.equal(JSON.parse(output[0]!.value).result.upstreamRevoked,true);
+	} finally {rmSync(root,{recursive:true,force:true});}
+});

--- a/tests/unit/command-boundary/auth/session-renewal.test.ts
+++ b/tests/unit/command-boundary/auth/session-renewal.test.ts
@@ -1,5 +1,4 @@
 import assert from 'node:assert/strict';
-import { createServer } from 'node:http';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -7,34 +6,36 @@ import test from 'node:test';
 import { createControlPlaneClient } from '../../../../src/cli/support/client.ts';
 import { loadServerSession, saveServerProfile, saveServerSession } from '../../../../src/cli/support/server-custody.ts';
 import type { CommandContext } from '../../../../src/cli/types.ts';
+import { apiResource, identityFixture, sessionBinding } from '../../../support/identity-fixture.ts';
 
-for (const rejectRenewal of [false, true]) test(`concurrent renewal is single-use and invalidates ambiguity (${rejectRenewal})`, async () => {
-	let requests = 0;
-	let baseUrl = '';
-	const server = createServer((request, response) => {
-		request.resume();
-		request.once('end', () => {
-			requests++;
-			response.setHeader('content-type', 'application/json');
-			if (rejectRenewal) { response.writeHead(503); response.end(JSON.stringify({error:'temporarily_unavailable'})); }
-			else response.end(JSON.stringify({token_type:'Bearer', access_token:'renewed', refresh_token:'rotated', expires_in:600, scope:'treeseed:read', audience:baseUrl}));
-		});
-	});
-	await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
-	const address = server.address(); assert.ok(address && typeof address !== 'string');
-	baseUrl = `http://127.0.0.1:${address.port}`;
-	const root = mkdtempSync(join(tmpdir(), 'treeseed-cli-renewal-'));
-	const env = { TREESEED_CONFIG_HOME: root };
-	const context: CommandContext = {cwd:root, env, write:()=>{}, outputFormat:'json', interactiveUi:false};
+for (const rejectRenewal of [false,true]) test(`concurrent Identity renewal is single-use and invalidates ambiguity (${rejectRenewal})`, async context => {
+	const fixture = await identityFixture(); fixture.state.rejectRenewal = rejectRenewal;
+	context.mock.method(globalThis,'fetch',fixture.transport);
+	const root = mkdtempSync(join(tmpdir(),'treeseed-cli-renewal-'));
+	const env = {TREESEED_CONFIG_HOME:root};
+	const commandContext:CommandContext = {cwd:root,env,write:()=>{},outputFormat:'json',interactiveUi:false};
 	try {
-		saveServerProfile({serverId:'test', label:'Test', baseUrl}, env);
-		await saveServerSession({serverId:'test', audience:baseUrl, accessToken:'expired', refreshToken:'old', expiresAt:'2020-01-01T00:00:00.000Z'}, env);
-		const results = await Promise.allSettled([1,2].map(() => createControlPlaneClient({options:{server:'test'}}, context, true, true)));
-		assert.equal(requests, 1);
-		assert.ok(results.every(result => result.status === (rejectRenewal ? 'rejected' : 'fulfilled')));
-		assert.equal(loadServerSession('test', env)?.refreshToken ?? null, rejectRenewal ? null : 'rotated');
-	} finally {
-		await new Promise<void>(resolve => server.close(() => resolve()));
-		rmSync(root, {recursive:true, force:true});
-	}
+		saveServerProfile({serverId:'test',label:'Test',baseUrl:apiResource},env);
+		await saveServerSession({...sessionBinding,serverId:'test',audience:apiResource,accessToken:'expired',refreshToken:'old',expiresAt:'2020-01-01T00:00:00.000Z'},env);
+		const results = await Promise.allSettled([1,2].map(()=>createControlPlaneClient({options:{server:'test'}},commandContext,true,true)));
+		assert.equal(fixture.state.tokenCalls,1);
+		assert.ok(results.every(result=>result.status === (rejectRenewal ? 'rejected':'fulfilled')));
+		assert.equal(loadServerSession('test',env)?.refreshToken ?? null,rejectRenewal ? null:'rotated');
+	} finally {rmSync(root,{recursive:true,force:true});}
+});
+
+test('changed subject fails renewal and old unbound sessions require fresh sign-in',async context=>{
+	const fixture = await identityFixture(); fixture.state.subject = 'other';
+	context.mock.method(globalThis,'fetch',fixture.transport);
+	const root = mkdtempSync(join(tmpdir(),'treeseed-cli-binding-')), env={TREESEED_CONFIG_HOME:root};
+	const commandContext:CommandContext={cwd:root,env,write:()=>{},outputFormat:'json',interactiveUi:false};
+	try {
+		saveServerProfile({serverId:'test',label:'Test',baseUrl:apiResource},env);
+		await saveServerSession({...sessionBinding,serverId:'test',audience:apiResource,accessToken:'old',refreshToken:'old',expiresAt:'2020-01-01T00:00:00.000Z'},env);
+		await assert.rejects(createControlPlaneClient({options:{server:'test'}},commandContext));
+		assert.equal(loadServerSession('test',env),null);
+		await saveServerSession({...sessionBinding,identity:undefined as never,serverId:'test',audience:apiResource,accessToken:'old'},env);
+		await assert.rejects(createControlPlaneClient({options:{server:'test'}},commandContext),{code:'identity_login_required'});
+		assert.equal(fixture.state.tokenCalls,1);
+	} finally {rmSync(root,{recursive:true,force:true});}
 });

--- a/tests/unit/command-boundary/canonical-client.test.ts
+++ b/tests/unit/command-boundary/canonical-client.test.ts
@@ -30,7 +30,7 @@ test('teams use persists the active team and team commands inherit it', async ()
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-team-')); const output: string[] = [];
 	const env = { TREESEED_CONFIG_HOME: root, TREESEED_API_BASE_URL: 'http://127.0.0.1:3002' };
 	try {
-		await saveServerSession({ serverId: 'local', audience: 'http://127.0.0.1:3002', accessToken: 'token', principal: { id: 'user-1' } as any }, env);
+		await saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[], serverId: 'local', audience: 'http://127.0.0.1:3002', accessToken: 'token', principal: { id: 'user-1' } as any }, env);
 		const invoke = async (operationId: string, input: any) => operationId === 'teams.list'
 			? { data: { items: [{ id: 'team-1', slug: 'treeseed', name: 'TreeSeed' }] } }
 			: { data: { operationId, teamId: input.path.teamId } };
@@ -101,7 +101,7 @@ test('host storage connect derives the active team and keeps bootstrap authority
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-storage-')); const calls: any[] = []; const output: string[] = [];
 	const env = { TREESEED_CONFIG_HOME: root, TREESEED_API_BASE_URL: 'http://127.0.0.1:3002' };
 	try {
-		await saveServerSession({ serverId: 'local', audience: 'http://127.0.0.1:3002', accessToken: 'session', principal: { id: 'user-1' } as any,
+		await saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[], serverId: 'local', audience: 'http://127.0.0.1:3002', accessToken: 'session', principal: { id: 'user-1' } as any,
 			activeTeam: { id: '16549507-cebc-4a16-94c5-cf91defbd6a3', slug: 'treeseed', name: 'TreeSeed' } }, env);
 		const exit = await runCommandLine(['host', 'storage', 'connect', 'cloudflare-r2', '--json'], {
 			env, interactiveUi: false, promptSecret: async () => 'bootstrap-token-secret-value',
@@ -310,7 +310,7 @@ for (const field of ['registrationCode', 'enrollmentToken']) test(`provider enro
 	try {
 		const profile = { serverId: 'test', label: 'Test', baseUrl: `http://127.0.0.1:${address.port}` };
 		saveServerProfile(profile, env);
-		await saveServerSession({ serverId: 'test', audience: profile.baseUrl, accessToken: 'access-token' }, env);
+		await saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[], serverId: 'test', audience: profile.baseUrl, accessToken: 'access-token' }, env);
 		const handoffs: Record<string, unknown>[] = [];
 		const output: string[] = [];
 		const exit = await runCommandLine(['providers', 'connect', '--server', 'test', '--team', 'team-1', '--yes', '--json'], {
@@ -355,7 +355,7 @@ test('seed apply enrolls, owner-approves, and waits for execution-ready provider
 	writeFileSync(file, `schemaVersion: treeseed.seed-bundle/v3\nname: treeseed\nversion: 4\ndescription: test\nenvironments: [local]\ndigest: sha256:${'0'.repeat(64)}\nresources: { teams: [], memberships: [], projects: [], repositories: [] }\nruntime: { capacityProviders: [] }\n`);
 	const env = { TREESEED_CONFIG_HOME: root, TREESEED_SEED_PROVIDER_TIMEOUT_SECONDS: '10' };
 	try {
-		const profile = { serverId: 'test', label: 'Test', baseUrl: `http://127.0.0.1:${address.port}` }; saveServerProfile(profile, env); await saveServerSession({ serverId: 'test', audience: profile.baseUrl, accessToken: 'access-token' }, env);
+		const profile = { serverId: 'test', label: 'Test', baseUrl: `http://127.0.0.1:${address.port}` }; saveServerProfile(profile, env); await saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[], serverId: 'test', audience: profile.baseUrl, accessToken: 'access-token' }, env);
 		const handoffs: Record<string, unknown>[] = []; const output: string[] = [];
 		const exit = await runCommandLine(['seeds', 'apply', file, '--server', 'test', '--yes', '--json'], { env, interactiveUi: false,
 			providerEnrollmentHandoff: async (input) => { handoffs.push(input); return input.action === 'begin' ? { requestId: 'request-1' } : { status: 'connected' }; }, write: (value) => output.push(value) });
@@ -404,7 +404,7 @@ test('high-risk operations replay the exact request with signed server confirmat
 	try {
 		const profile = { serverId: 'test', label: 'Test', baseUrl: `http://127.0.0.1:${address.port}` };
 		saveServerProfile(profile, env);
-		await saveServerSession({ serverId: 'test', audience: profile.baseUrl, accessToken: 'access-token' }, env);
+		await saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[], serverId: 'test', audience: profile.baseUrl, accessToken: 'access-token' }, env);
 		const output: string[] = [];
 		const exit = await runCommandLine(['workdays', 'start', '--server', 'test', '--team', 'team-1', '--preflight', 'p1', '--digest', 'sha256:x', '--yes', '--json'], { env, interactiveUi: false, write: (value) => output.push(value) });
 		assert.equal(exit, 0);
@@ -413,82 +413,6 @@ test('high-risk operations replay the exact request with signed server confirmat
 		assert.equal(requests[0]!.idempotency, requests[1]!.idempotency);
 		assert.equal(requests[0]!.confirmation, undefined);
 		assert.deepEqual(JSON.parse(Buffer.from(requests[1]!.confirmation!, 'base64url').toString('utf8')), confirmation);
-	} finally {
-		await new Promise<void>((accept, reject) => server.close((error) => error ? reject(error) : accept()));
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
-test('expired sessions rotate through OAuth before invoking the operation', async () => {
-	const requests: Array<{ url: string; authorization: string | undefined; body: string }> = [];
-	let baseUrl = '';
-	const server = createServer((request, response) => {
-		let body = '';
-		request.on('data', (chunk) => { body += String(chunk); });
-		request.on('end', () => {
-			requests.push({ url: request.url ?? '', authorization: request.headers.authorization, body });
-			response.setHeader('content-type', 'application/json');
-			response.end(JSON.stringify(request.url === '/oauth/token'
-				? { token_type: 'Bearer', access_token: 'new-access', refresh_token: 'new-refresh', expires_in: 600, scope: 'treeseed:read', audience: baseUrl }
-				: { data: { healthy: true } }));
-		});
-	});
-	await new Promise<void>((accept) => server.listen(0, '127.0.0.1', accept));
-	const address = server.address();
-	if (!address || typeof address === 'string') throw new Error('Test server did not bind.');
-	baseUrl = `http://127.0.0.1:${address.port}`;
-	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-refresh-'));
-	const env = { TREESEED_CONFIG_HOME: root };
-	try {
-		saveServerProfile({ serverId: 'test', label: 'Test', baseUrl }, env);
-		await saveServerSession({ serverId: 'test', audience: baseUrl, accessToken: 'expired-access', refreshToken: 'old-refresh', expiresAt: '2020-01-01T00:00:00.000Z' }, env);
-		const output: string[] = [];
-		const exit = await runCommandLine(['status', '--server', 'test', '--json'], { env, interactiveUi: false, write: (value) => output.push(value) });
-		assert.equal(exit, 0);
-		assert.deepEqual(JSON.parse(output[0]!).result, { healthy: true });
-		assert.equal(requests[0]!.url, '/oauth/token');
-		assert.match(requests[0]!.body, /grant_type=refresh_token/u);
-		assert.equal(requests[1]!.authorization, 'Bearer new-access');
-		assert.equal(loadServerSession('test', env)?.refreshToken, 'new-refresh');
-	} finally {
-		await new Promise<void>((accept, reject) => server.close((error) => error ? reject(error) : accept()));
-		rmSync(root, { recursive: true, force: true });
-	}
-});
-
-test('JSON device login keeps human approval instructions off stdout', async () => {
-	let baseUrl = '';
-	const server = createServer((request, response) => {
-		response.setHeader('content-type', 'application/json');
-		response.end(JSON.stringify(request.url === '/oauth/device_authorization'
-			? { device_code: 'device-a', user_code: 'ABCD-EFGH', verification_uri: `${baseUrl}/approve`,
-				verification_uri_complete: `${baseUrl}/approve?user_code=ABCD-EFGH`, expires_in: 60, interval: 0 }
-			: request.url === '/oauth/token' ? { token_type: 'Bearer', access_token: 'access-a', refresh_token: 'refresh-a', expires_in: 600,
-				scope: 'treeseed:read', audience: baseUrl }
-				: { data: { principal: { id: 'user-a', displayName: 'Adrian Webb' }, teams: [] } }));
-	});
-	await new Promise<void>((accept) => server.listen(0, '127.0.0.1', accept));
-	const address = server.address();
-	if (!address || typeof address === 'string') throw new Error('Test server did not bind.');
-	baseUrl = `http://127.0.0.1:${address.port}`;
-	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-device-'));
-	const output: Array<{ value: string; stream?: string }> = [];
-	const opened: string[] = [];
-	try {
-		saveServerProfile({ serverId: 'test', label: 'Test', baseUrl }, { TREESEED_CONFIG_HOME: root });
-		const exit = await runCommandLine(['auth', 'login', '--server', 'test', '--json'], {
-			env: { TREESEED_CONFIG_HOME: root }, interactiveUi: false,
-			write: (value, stream) => output.push({ value, stream }),
-			openExternal: async (url) => { opened.push(url); return true; },
-		});
-		assert.equal(exit, 0, JSON.stringify(output));
-		assert.deepEqual(opened, [`${baseUrl}/approve?user_code=ABCD-EFGH`]);
-		assert.match(output.filter(({ stream }) => stream === 'stderr').map(({ value }) => value).join('\n'), /Opened your default browser/u);
-		assert.match(output.filter(({ stream }) => stream === 'stderr').map(({ value }) => value).join('\n'), /another computer.*ABCD-EFGH/u);
-		const stdout = output.filter(({ stream }) => stream === 'stdout');
-		assert.equal(stdout.length, 1);
-		assert.equal(JSON.parse(stdout[0]!.value).ok, true);
-		assert.equal(JSON.parse(stdout[0]!.value).result.principal.displayName, 'Adrian Webb');
 	} finally {
 		await new Promise<void>((accept, reject) => server.close((error) => error ? reject(error) : accept()));
 		rmSync(root, { recursive: true, force: true });

--- a/tests/unit/command-boundary/host-storage-reset.test.ts
+++ b/tests/unit/command-boundary/host-storage-reset.test.ts
@@ -11,7 +11,7 @@ test('host storage reset is destructive, environment-bounded, and uses retained 
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-storage-reset-')); const calls: any[] = [];
 	const env = { TREESEED_CONFIG_HOME: root, TREESEED_API_BASE_URL: 'http://127.0.0.1:3002' };
 	try {
-		await saveServerSession({ serverId: 'local', audience: 'http://127.0.0.1:3002', accessToken: 'session', principal: { id: 'user-1' } as any,
+		await saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[], serverId: 'local', audience: 'http://127.0.0.1:3002', accessToken: 'session', principal: { id: 'user-1' } as any,
 			activeTeam: { id: '16549507-cebc-4a16-94c5-cf91defbd6a3', slug: 'treeseed', name: 'TreeSeed' } }, env);
 		assert.equal(await runCommandLine(['host', 'storage', 'reset', 'cloudflare-r2', '--environment', 'preview', '--yes', '--json'], {
 			env, interactiveUi: false, hostInvoke: async (input) => calls.push(input), write() {},

--- a/tests/unit/command-boundary/host/provider-environment.test.ts
+++ b/tests/unit/command-boundary/host/provider-environment.test.ts
@@ -23,7 +23,7 @@ test('provider code rotation pre-reads and replays the exact response ETag', asy
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-provider-code-')); const env = { TREESEED_CONFIG_HOME: root };
 	try {
 		const profile = { serverId: 'test', label: 'Test', baseUrl: `http://127.0.0.1:${address.port}` };
-		saveServerProfile(profile, env); await saveServerSession({ serverId: 'test', audience: profile.baseUrl, accessToken: 'access-token' }, env);
+		saveServerProfile(profile, env); await saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[], serverId: 'test', audience: profile.baseUrl, accessToken: 'access-token' }, env);
 		assert.equal(await runCommandLine(['providers', 'registration', 'code', 'rotate', '--server', 'test', '--team', 'team-1', '--yes', '--json'], { env, interactiveUi: false, write() {} }), 0);
 		assert.deepEqual(requests, [
 			{ method: 'GET', url: '/v1/teams/team-1/capacity-provider-registration-code', ifMatch: undefined },

--- a/tests/unit/command-boundary/server-custody.test.ts
+++ b/tests/unit/command-boundary/server-custody.test.ts
@@ -21,7 +21,7 @@ test('server profiles and encrypted OAuth sessions remain CLI-local and redacted
 	const env = { TREESEED_CONFIG_HOME: root };
 	try {
 		saveServerProfile({ serverId: 'test', label: 'Test', baseUrl: 'https://control.example.test' }, env);
-		await saveServerSession({ serverId: 'test', audience: 'https://control.example.test', accessToken: 'secret-access', refreshToken: 'secret-refresh', principal: null }, env);
+		await saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[], serverId: 'test', audience: 'https://control.example.test', accessToken: 'secret-access', refreshToken: 'secret-refresh', principal: null }, env);
 		await saveActiveTeam('test', { id: 'team-1', slug: 'treeseed', name: 'TreeSeed' }, env);
 		assert.equal(loadServerSession('test', env)?.accessToken, 'secret-access');
 		assert.equal(loadServerSession('test', env)?.activeTeam?.slug, 'treeseed');
@@ -64,7 +64,7 @@ test('session transactions preserve concurrent server and team edits and invalid
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-transactions-'));
 	const env = { TREESEED_CONFIG_HOME: root };
 	try {
-		await Promise.all(['one', 'two'].map(serverId => saveServerSession({serverId, audience:'https://api.example.test', accessToken:'old', refreshToken:'refresh'}, env)));
+		await Promise.all(['one', 'two'].map(serverId => saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[],serverId, audience:'https://api.example.test', accessToken:'old', refreshToken:'refresh'}, env)));
 		assert.deepEqual(inspectServerCustody(env).servers.map(entry => entry.serverId), ['one','two']);
 		let release!: () => void;
 		let entered!: () => void;
@@ -92,7 +92,7 @@ test('logout waits for renewal and a queued renewal cannot resurrect a removed s
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-logout-race-'));
 	const env = { TREESEED_CONFIG_HOME: root };
 	try {
-		await saveServerSession({serverId:'one', audience:'https://api.example.test', accessToken:'old'}, env);
+		await saveServerSession({identity:{issuer:'https://identity.example.test/realms/local',subject:'user'},clientId:'trsd',scopes:[],serverId:'one', audience:'https://api.example.test', accessToken:'old'}, env);
 		let entered!: () => void;
 		let release!: () => void;
 		const started = new Promise<void>(resolve => { entered = resolve; });


### PR DESCRIPTION
## Outcome
Replace CLI calls to the API's retired issuer with Identity discovery, browser PKCE, explicit headless device login and issuer-bound renewal/logout.

## Work authority
- Work item / Issue: #158
- Proposal / decision: User-approved Identity, SSO, and Explicit Federation plan
- Assignment / checkpoint: Direct local implementation; no TreeSeed assignment
- Actor: Codex
- Human authority: @adrianwebb
- Agent / capacity provider: Local Codex; no capacity-provider assignment
- Exact base ref: staging 83a1a1f961769c25d8406aac760bb4778980d7b7
- Exact head ref: codex/identity-client-integration aaa13bce236f9604a64c94e2653f9d33d7d5e1ac

Contributor mode (select one):
- [ ] Human-authored
- [ ] Agent-assisted under human authority
- [x] Agent-authored under human authority

## Plan
Implement this bounded Identity integration slice, require exact-head checks, and keep live cutover coordinated with managed database/account migration.

## Changes and commits
458b6cd9d6324c6933a3924d65efd64cdb2e1a26: Consume published Identity rc9 and SDK rc106. Temporary exact-host loopback callback, server-side token verification, OS-encrypted binding, current API principal resolution, no email linking, no legacy token fallback. Preserve team choice only for the same verified identity. Replace legacy issuer fixtures with signed Identity fixtures; retain custody race regressions. Handle optional credential authority schemes safely.

Follow-up e3998bf43a9c1b87791e133083d33f8aaeacb397 updates the release dependency allowlist for the shared Identity adapter; complete local release verification and extracted-package smoke now pass.

Version-only follow-up aaa13bce236f9604a64c94e2653f9d33d7d5e1ac prepares rc69 for disposable acceptance; rc68 already exists and will never be replaced.

## Verification
Build, strict source typecheck, strict new-test typecheck, architecture policy and all 136 tests passed. Real Keycloak adapter acceptance is Deployment 34334150844; Identity rc9 publication 34335729786 and SDK rc106 publication 34336646515 passed. CLI-to-managed-Keycloak acceptance still follows this slice.

- [x] I ran the narrowest relevant package verification and documented any checks that could not be run.

## Risk and rollback
An immutable CLI candidate may be published for disposable acceptance, but do not select it on the live host until the API advertises and accepts Identity. Existing unbound sessions require fresh sign-in (user-approved invalidation); no provider/user IDs or secret values are changed. Revert before coordinated cutover if needed. Existing consumers stay on pinned releases.

## Completion summary
Implementation and local verification complete; Actions pending. Full Identity plan and managed acceptance remain open.

## Submission checklist
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
