### PR TITLE
Resolve declared host runtime dependency closure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.70",
+  "version": "0.13.0-rc.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.70",
+      "version": "0.13.0-rc.71",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.70",
+  "version": "0.13.0-rc.71",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/development-support/host-dependencies.ts
+++ b/src/cli/commands/development-support/host-dependencies.ts
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+
+type Package = { dependencies?: Record<string, string>; optionalDependencies?: Record<string, string>; treeseed?: { hostRuntimeDependencies?: string[] } };
+const read = (root: string): Package => JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+
+/** Deployment declares its runtime roots; npm's installed graph supplies their closure. */
+export function hostDependencyRoots(worktree: string): string[] {
+	const root = realpathSync(worktree), manifest = read(root);
+	const names = manifest.treeseed?.hostRuntimeDependencies;
+	if (!Array.isArray(names) || !names.length) throw new Error('Deployment must declare hostRuntimeDependencies.');
+	const found = new Set<string>();
+	function visit(name: string, issuer: string, optional = false) {
+		if (!/^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/iu.test(name)) throw new Error('Invalid host runtime dependency name.');
+		let cursor = issuer, selected: string | undefined;
+		while (cursor === root || cursor.startsWith(root + sep)) {
+			const candidate = resolve(cursor, 'node_modules', name);
+			if (existsSync(resolve(candidate, 'package.json'))) { selected = candidate; break; }
+			cursor = dirname(cursor);
+		}
+		if (!selected) { if (optional) return; throw new Error(`Host runtime dependency is missing: ${name}`); }
+		if (realpathSync(selected) !== selected) throw new Error('Host runtime dependency contains a symbolic link.');
+		if (found.has(selected)) return;
+		found.add(selected);
+		const pkg = read(selected);
+		for (const dependency of Object.keys({ ...pkg.dependencies, ...pkg.optionalDependencies })) visit(dependency, selected, dependency in (pkg.optionalDependencies ?? {}));
+	}
+	for (const name of names) {
+		if (!(name in (manifest.dependencies ?? {}))) throw new Error('Host runtime root must be a production dependency.');
+		visit(name, root);
+	}
+	return [...found].sort();
+}

--- a/src/cli/commands/development-support/host-runtime.ts
+++ b/src/cli/commands/development-support/host-runtime.ts
@@ -25,8 +25,7 @@ function files(root: string, directory: string, include: (path: string) => boole
 }
 
 export function hostDevelopmentRuntimeManifest(worktree: string) {
-	// Ship only the production dependency closure. Host sandbox code imports the
-	// narrow SDK sandbox boundary, so TreeDX and TypeScript remain outside it.
+	// Deployment owns the runtime roots; preserve their installed resolution graph.
 	const roots = [resolve(worktree, 'dist'), ...hostDependencyRoots(worktree)];
 	for (const root of roots) if (!existsSync(root)) throw new Error(`Host development runtime dependency is missing: ${relative(worktree, root)}.`);
 	const packageContent = readFileSync(resolve(worktree, 'package.json'));

--- a/src/cli/commands/development-support/host-runtime.ts
+++ b/src/cli/commands/development-support/host-runtime.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, w
 import { basename, relative, resolve } from 'node:path';
 import type { CommandContext, ParsedInvocation } from '../../types.js';
 import { invokeLocalHostManager } from '../../support/host-client.js';
+import { hostDependencyRoots } from './host-dependencies.js';
 
 interface DevelopmentFile { path: string; size: number; sha256: string }
 
@@ -26,19 +27,11 @@ function files(root: string, directory: string, include: (path: string) => boole
 export function hostDevelopmentRuntimeManifest(worktree: string) {
 	// Ship only the production dependency closure. Host sandbox code imports the
 	// narrow SDK sandbox boundary, so TreeDX and TypeScript remain outside it.
-	const dependencies = ['@treeseed/sdk', 'yaml', 'zod'];
-	const roots = [resolve(worktree, 'dist'), ...dependencies.map((dependency) => resolve(worktree, 'node_modules', dependency))];
+	const roots = [resolve(worktree, 'dist'), ...hostDependencyRoots(worktree)];
 	for (const root of roots) if (!existsSync(root)) throw new Error(`Host development runtime dependency is missing: ${relative(worktree, root)}.`);
 	const packageContent = readFileSync(resolve(worktree, 'package.json'));
-	const sdkRoot = resolve(worktree, 'node_modules', '@treeseed', 'sdk');
 	const productionRuntimeFile = (path: string) => {
-		if (!/(?:\.js|\.json|\.node|\.wasm)$/u.test(path) || /\.map$/u.test(path)) return false;
-		if (!path.startsWith(`${sdkRoot}/`)) return true;
-		const sdkPath = relative(sdkRoot, path);
-		return sdkPath === 'package.json' || sdkPath.startsWith('dist/deployment/') || sdkPath.startsWith('dist/development/')
-			|| sdkPath.startsWith('dist/secrets-capability/') || sdkPath === 'dist/configuration/secrets-capability.js'
-			|| sdkPath.startsWith('dist/capacity-provider/contracts/')
-			|| sdkPath === 'dist/capacity-provider/sandbox.js' || sdkPath === 'dist/capacity-provider/sandbox-contracts.js';
+		return /\.(?:[cm]?js|json|node|wasm)$/u.test(path);
 	};
 	return [{ path: 'package.json', size: packageContent.byteLength, sha256: sha256(packageContent) }, ...roots.flatMap((root) => files(worktree, root, productionRuntimeFile))].sort((left, right) => left.path.localeCompare(right.path));
 }

--- a/tests/unit/command-boundary/development-session.test.ts
+++ b/tests/unit/command-boundary/development-session.test.ts
@@ -93,7 +93,7 @@ test('host runtime includes the SDK capacity-provider contracts required by Depl
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-host-runtime-'));
 	try {
 		for (const directory of ['dist', 'node_modules/@treeseed/sdk/dist/deployment', 'node_modules/@treeseed/sdk/dist/development', 'node_modules/@treeseed/sdk/dist/capacity-provider/contracts', 'node_modules/yaml', 'node_modules/zod']) mkdirSync(resolve(root, directory), { recursive: true });
-		writeFileSync(resolve(root, 'package.json'), '{}\n');
+		writeFileSync(resolve(root, 'package.json'), JSON.stringify({ dependencies: { '@treeseed/sdk': '1' }, treeseed: { hostRuntimeDependencies: ['@treeseed/sdk'] } }));
 		writeFileSync(resolve(root, 'dist/index.js'), 'export {};\n');
 		writeFileSync(resolve(root, 'node_modules/@treeseed/sdk/package.json'), '{}\n');
 		writeFileSync(resolve(root, 'node_modules/@treeseed/sdk/dist/deployment/index.js'), 'export {};\n');

--- a/tests/unit/command-boundary/development/host-dependencies.test.ts
+++ b/tests/unit/command-boundary/development/host-dependencies.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdirSync, mkdtempSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { hostDependencyRoots } from '../../../src/cli/commands/development-support/host-dependencies.ts';
+import { hostDependencyRoots } from '../../../../src/cli/commands/development-support/host-dependencies.ts';
 
 test('host custody includes nested production dependencies but not development-only packages', () => {
 	const root = mkdtempSync(join(tmpdir(), 'host-closure-'));

--- a/tests/unit/command-boundary/host-dependencies.test.ts
+++ b/tests/unit/command-boundary/host-dependencies.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { hostDependencyRoots } from '../../../src/cli/commands/development-support/host-dependencies.ts';
+
+test('host custody includes nested production dependencies but not development-only packages', () => {
+	const root = mkdtempSync(join(tmpdir(), 'host-closure-'));
+	const pkg = (path: string, data: unknown) => { mkdirSync(path, { recursive: true }); writeFileSync(join(path, 'package.json'), JSON.stringify(data)); };
+	try {
+		pkg(root, { dependencies: { pg: '1' }, devDependencies: { tooling: '1' }, treeseed: { hostRuntimeDependencies: ['pg'] } });
+		pkg(join(root, 'node_modules/pg'), { dependencies: { protocol: '1' }, optionalDependencies: { optional: '1' } });
+		pkg(join(root, 'node_modules/pg/node_modules/protocol'), {});
+		pkg(join(root, 'node_modules/tooling'), {});
+		assert.deepEqual(hostDependencyRoots(root), [join(root, 'node_modules/pg'), join(root, 'node_modules/pg/node_modules/protocol')]);
+		rmSync(join(root, 'node_modules/pg/node_modules/protocol'), { recursive: true });
+		assert.throws(() => hostDependencyRoots(root), /missing: protocol/);
+		symlinkSync(join(root, 'node_modules/tooling'), join(root, 'node_modules/pg/node_modules/protocol'));
+		assert.throws(() => hostDependencyRoots(root), /symbolic link/);
+	} finally { rmSync(root, { recursive: true }); }
+});


### PR DESCRIPTION
Part of #164 and treeseed-ai/deployment#622. Replace the fixed dependency list with Deployment-owned hostRuntimeDependencies and recursive installed production dependency resolution, preserving nested packages and rejecting symlinks/missing required packages. Include CJS/MJS runtime files; keep development-only dependencies outside the closure.

Validation: build/lint, 137 standard tests, 10 development-session tests and new nested-closure negative tests pass locally. Requires paired Deployment supervisor update before managed activation; existing runtime remains active on rejection. Automatic process recovery and reboot acceptance remain tracked and are not claimed complete.