### PR TITLE
Fix cold development recovery dependency ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.72",
+  "version": "0.13.0-rc.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.72",
+      "version": "0.13.0-rc.73",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.72",
+  "version": "0.13.0-rc.73",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/development-support/boot-order.ts
+++ b/src/cli/commands/development-support/boot-order.ts
@@ -1,0 +1,25 @@
+import type { DevelopmentRuntime } from '@treeseed/sdk/development';
+
+type Selection = { projectId: string; targetId: string; mode: string };
+
+/** Start selected prerequisites before consumers, regardless of saved UI order. */
+export function developmentBootOrder<T extends Selection>(selections: T[], runtimes: DevelopmentRuntime[]): T[] {
+	const key = (entry: Selection) => `${entry.projectId}.${entry.targetId}`;
+	const selected = new Map(selections.filter(entry => entry.mode !== 'released').map(entry => [key(entry), entry]));
+	const ordered: T[] = [], visiting = new Set<string>(), visited = new Set<string>();
+	function visit(entry: T): void {
+		const id = key(entry);
+		if (visited.has(id)) return;
+		if (visiting.has(id)) throw new Error(`Development startup dependency cycle at ${id}.`);
+		visiting.add(id);
+		const target = runtimes.find(runtime => runtime.project.id === entry.projectId)?.targets.find(target => target.id === entry.targetId);
+		if (!target) throw new Error(`Development runtime is missing for ${id}.`);
+		for (const dependency of target.dependencies) {
+			const prerequisite = selected.get(`${dependency.id}.${dependency.target}`);
+			if (prerequisite) visit(prerequisite);
+		}
+		visiting.delete(id); visited.add(id); ordered.push(entry);
+	}
+	for (const entry of selected.values()) visit(entry);
+	return ordered;
+}

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -13,6 +13,7 @@ import { artifactPaths, compatibilityAttestations, withFreezeLock } from './deve
 import { runHostDevelopment } from './development-support/host-runtime.js';
 import { applyDevelopmentRecovery, planDevelopmentRecovery } from './development-support/recovery.js';
 import { ownsDevelopmentProcess, processIdentity } from './development-support/process-identity.js';
+import { developmentBootOrder } from './development-support/boot-order.js';
 export { relativeOverlayTarget, startPackageSynchronizer, stopProcess, waitForNewPackageOverlay } from './development-support/overlays.js';
 
 export { developmentCliEntrypointPath, selectDevelopmentCli } from './development-cli-selection.js';
@@ -404,7 +405,7 @@ export async function resumeDevelopmentSession(sessionId: string, context: Comma
 	loadState(context.env, sessionId);
 	const record = await invoke(context, 'local.dev.status', { sessionId, all: false }) as DevelopmentStatusRecord & { session: { status: string } };
 	if (record.session.status === 'stopped') return;
-	for (const target of record.session.targets.filter(target => target.mode !== 'released')) {
+	for (const target of developmentBootOrder(record.session.targets, record.runtimes)) {
 		const current = await invoke(context, 'local.dev.status', { sessionId, all: false }) as typeof record;
 		if (current.session.status === 'stopped') return;
 		const selected = current.session.targets.find(entry => entry.projectId === target.projectId && entry.targetId === target.targetId);

--- a/tests/unit/command-boundary/development/boot-order.test.ts
+++ b/tests/unit/command-boundary/development/boot-order.test.ts
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { DevelopmentRuntime } from '@treeseed/sdk/development';
+import { developmentBootOrder } from '../../../../src/cli/commands/development-support/boot-order.ts';
+
+function runtime(id: string, target: string, dependencies: Array<[string, string]> = []) {
+	return { project: { id }, targets: [{ id: target, dependencies: dependencies.map(([id, target]) => ({ id, target, reaction: 'none' })) }] } as DevelopmentRuntime;
+}
+const selections = [
+	{ projectId: 'admin', targetId: 'web', mode: 'live' },
+	{ projectId: 'api', targetId: 'service', mode: 'live' },
+	{ projectId: 'deployment', targetId: 'package', mode: 'live' },
+	{ projectId: 'sdk', targetId: 'package', mode: 'released' },
+];
+test('cold boot starts API before Admin and package dependencies before API', () => {
+	const ordered = developmentBootOrder(selections, [runtime('admin', 'web', [['api', 'service']]), runtime('api', 'service', [['deployment', 'package'], ['sdk', 'package']]), runtime('deployment', 'package')]);
+	assert.deepEqual(ordered.map(entry => entry.projectId), ['deployment', 'api', 'admin']);
+	const ready = new Set<string>();
+	for (const entry of ordered) {
+		if (entry.projectId === 'admin') assert.ok(ready.has('api'));
+		if (entry.projectId === 'api') assert.ok(ready.has('deployment'));
+		ready.add(entry.projectId);
+	}
+});
+test('cycles fail before startup and missing selected contracts fail closed', () => {
+	assert.throws(() => developmentBootOrder(selections.slice(0, 2), [runtime('admin', 'web', [['api', 'service']]), runtime('api', 'service', [['admin', 'web']])]), /dependency cycle/);
+	assert.throws(() => developmentBootOrder(selections, []), /runtime is missing/);
+});
+test('released and external dependencies do not create local processes', () => {
+	assert.deepEqual(developmentBootOrder([selections[0]!, selections[3]!], [runtime('admin', 'web', [['sdk', 'package'], ['remote', 'service']])]), [selections[0]]);
+});


### PR DESCRIPTION
## Contract
Refs #166 and treeseed-ai/deployment#622. Saved target order started Admin before API, while Admin readiness requires API. A cold reboot timed out and systemd cleaned up the worker processes repeatedly.

Topologically order selected targets using published runtime dependencies; skip released/external dependencies and reject missing contracts/cycles before startup. Preserve current-selection checks, readiness gates, and non-root custody. Prepare rc73.

## Evidence
141 local tests pass, strict build and file policy pass. Cold recovery regression covers consumer-first saved order, package prerequisites, external/released dependencies, and cycles. Actions is required before merge. Live host recovery uses the companion Deployment fix; full installed cold acceptance remains open.

## Rollback
Prior immutable CLI/runtime; no schema, authentication, or state changes. No main changes.