### PR TITLE
Fix unattended lifecycle contention and prepare CLI rc75

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.74",
+  "version": "0.13.0-rc.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.74",
+      "version": "0.13.0-rc.75",
       "bundleDependencies": [
         "ink",
         "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.74",
+  "version": "0.13.0-rc.75",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/cli/commands/development-support/lifecycle.ts
+++ b/src/cli/commands/development-support/lifecycle.ts
@@ -6,9 +6,25 @@ import { developmentStateRoot } from '../development-cli-selection.js';
  * operator's lifecycle, not a time-limited development selection. Deployment
  * owns the kernel-lock implementation; process death releases its descriptor.
  */
-export function withDevelopmentLifecycle<T>(env: NodeJS.ProcessEnv, action: () => Promise<T>): Promise<T> {
+export async function withDevelopmentLifecycle<T>(env: NodeJS.ProcessEnv, action: () => Promise<T>, options: {
+    waitForOwner?: boolean;
+    lockTimeoutSeconds?: number;
+} = {}): Promise<T> {
     if (process.platform !== 'linux') return action();
-    return withOsCustodyLock(resolve(developmentStateRoot(env), 'lifecycle'), action, 60);
+    for (;;) {
+        let entered = false;
+        try {
+            return await withOsCustodyLock(resolve(developmentStateRoot(env), 'lifecycle'), async () => {
+                entered = true;
+                return action();
+            }, options.lockTimeoutSeconds ?? 60);
+        } catch (error) {
+            // Only unattended acquisition waits again. Never replay a partially
+            // executed lifecycle, even if it throws the same custody message.
+            if (!options.waitForOwner || entered || !(error instanceof Error)
+                || error.message !== 'OS custody is busy; retry the operation') throw error;
+        }
+    }
 }
 
 /** Reusing an immutable snapshot is not permission to overwrite its contents.

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -406,7 +406,7 @@ async function rebuild(invocation: ParsedInvocation, context: CommandContext, st
 
 /** Resume only current manager selections; never reconstruct desired state from stale PIDs. */
 export async function resumeDevelopmentSession(sessionId: string, context: CommandContext) {
-	return withDevelopmentLifecycle(context.env, () => resumeDevelopmentUnlocked(sessionId, context));
+	return withDevelopmentLifecycle(context.env, () => resumeDevelopmentUnlocked(sessionId, context), { waitForOwner: true });
 }
 
 async function resumeDevelopmentUnlocked(sessionId: string, context: CommandContext) {

--- a/tests/unit/command-boundary/development/lifecycle.test.ts
+++ b/tests/unit/command-boundary/development/lifecycle.test.ts
@@ -42,6 +42,37 @@ test('lifecycle lock releases after a failed operation', { skip: process.platfor
     } finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('boot acquisition survives a timeout window while manual acquisition stays bounded', { skip: process.platform !== 'linux', timeout: 15000 }, async () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'lifecycle-boot-wait-'));
+    const owner = child(root);
+    const env = { XDG_STATE_HOME: root };
+    let runs = 0;
+    try {
+        assert.equal((await once(owner, 'message'))[0], 'entered');
+        const queued = withDevelopmentLifecycle(env, async () => { runs++; return 'ready'; }, { waitForOwner: true, lockTimeoutSeconds: 1 });
+        await assert.rejects(withDevelopmentLifecycle(env, async () => assert.fail('manual entered'), { lockTimeoutSeconds: 1 }), /OS custody is busy/);
+        await delay(300);
+        assert.equal(runs, 0);
+        const exited = once(owner, 'exit'); owner.send('release'); await exited;
+        assert.equal(await queued, 'ready');
+        assert.equal(runs, 1);
+    } finally { await stop(owner); rmSync(root, { recursive: true, force: true }); }
+});
+
+test('boot waiting never replays action errors or retries invalid lock configuration', { skip: process.platform !== 'linux', timeout: 5000 }, async () => {
+    const root = mkdtempSync(resolve(tmpdir(), 'lifecycle-no-replay-'));
+    let runs = 0;
+    try {
+        await assert.rejects(withDevelopmentLifecycle({ XDG_STATE_HOME: root }, async () => {
+            runs++; throw new Error('OS custody is busy; retry the operation');
+        }, { waitForOwner: true }), /OS custody is busy/);
+        assert.equal(runs, 1);
+        await assert.rejects(withDevelopmentLifecycle({ XDG_STATE_HOME: root }, async () => assert.fail('entered'), {
+            waitForOwner: true, lockTimeoutSeconds: 0,
+        }), /Invalid custody lock timeout/);
+    } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('healthy exact managed snapshot is reusable; missing runtime requires startup', () => {
     const state = JSON.stringify({ Name: 'treeseed-dev-test-api-operations-runner', State: 'running', Health: 'healthy' });
     assert.equal(managedContainerAlreadyReady({ registered: true, state }, 'dev-test', 'operations-runner'), true);


### PR DESCRIPTION
## Contract
Addresses #172 and Deployment#633/#637. A real reboot showed the main development session taking longer than the60-second kernel-lock acquisition window. Two queued boot workers exited instead of resuming.

Automatic resume now waits through acquisition contention. Manual commands retain bounded failure. The action-entry guard prohibits replay after any partial execution, including errors with the same custody message; other acquisition failures propagate. Selection state is still re-read inside the lock. No expiring selection, owner kill, lock deletion, credential reset, or Identity cutover.

## Verification
Seven targeted real-subprocess/lifecycle tests pass, including timeout-window waiting, manual timeout, owner death, no replay, invalid configuration, and immutable candidate reuse. Extracted CLI custody import and build/file architecture checks pass. Actions are required before merge. rc75 is bundled to avoid a redundant version-only verification chain.

## Rollback
Revert through staging and use managed updater. Preserve active source/state; no purge/bootstrap. Cold-boot acceptance stays open separately.