### PR TITLE
Align CLI SDK/Identity custody for the authentication rollout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.77",
+  "version": "0.13.0-rc.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.77",
+      "version": "0.13.0-rc.78",
       "bundleDependencies": [
         "ink",
         "react",
@@ -15,8 +15,8 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/identity": "0.1.0-rc.18",
-        "@treeseed/sdk": "0.13.0-rc.109",
+        "@treeseed/identity": "0.1.0-rc.21",
+        "@treeseed/sdk": "0.13.0-rc.110",
         "ink": "^7.1.1",
         "react": "^19.2.8",
         "string-width": "^8.2.2",
@@ -4717,9 +4717,9 @@
       }
     },
     "node_modules/@treeseed/identity": {
-      "version": "0.1.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@treeseed/identity/-/identity-0.1.0-rc.18.tgz",
-      "integrity": "sha512-yPOY2ZVpW5vb6/cr1ejcqIBaFKr5kHoKbrpjHleoqtlladLp71RpV5QV1oSubx1xwczBIjT5xUOTAB2Gem8UOQ==",
+      "version": "0.1.0-rc.21",
+      "resolved": "https://registry.npmjs.org/@treeseed/identity/-/identity-0.1.0-rc.21.tgz",
+      "integrity": "sha512-b9eOSZeukoZtEH76mQN4l0i/AcHtgY/TVYQQxcp7ohhjDtsM2SFiUQBz4rcg73Pol0bw9jjI8tSZ8dyb4LkRkA==",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.108",
         "jose": "6.2.12",
@@ -5176,9 +5176,9 @@
       }
     },
     "node_modules/@treeseed/sdk": {
-      "version": "0.13.0-rc.109",
-      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.109.tgz",
-      "integrity": "sha512-6+Fs7MovSYOy2gnKBeA8mPULZU9CkZ1IyXPbNqwU9+IhiRGR02Z3Lm/pz6og1ylt0B4zgqoYK+eR7RsvQVd0wQ==",
+      "version": "0.13.0-rc.110",
+      "resolved": "https://registry.npmjs.org/@treeseed/sdk/-/sdk-0.13.0-rc.110.tgz",
+      "integrity": "sha512-3R7dNn/Savuv43vJH2n+HDQLXDeCVm/TjiVF270P3xFrRE4g4yIrcA/BT1rrVPsxRVxfLbmLHxZaSFqMhgIRQQ==",
       "dependencies": {
         "@treeseed/treedx": "0.3.0-rc.17",
         "esbuild": "^0.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.77",
+  "version": "0.13.0-rc.78",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -51,8 +51,8 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/identity": "0.1.0-rc.18",
-    "@treeseed/sdk": "0.13.0-rc.109",
+    "@treeseed/identity": "0.1.0-rc.21",
+    "@treeseed/sdk": "0.13.0-rc.110",
     "ink": "^7.1.1",
     "react": "^19.2.8",
     "string-width": "^8.2.2",


### PR DESCRIPTION
Closes #177. Exact SDK rc110 and Identity rc21 pins for the shared host payload closure, CLI rc78. Independent build passes; native authentication tests run through the Node test runner (not Vitest). No CLI command or credential format changes. Actions must pass before promotion; registry read-back and managed acceptance follow.