### PR TITLE
Align CLI rc79 with accepted Identity favicon correction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.78",
+  "version": "0.13.0-rc.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treeseed/cli",
-      "version": "0.13.0-rc.78",
+      "version": "0.13.0-rc.79",
       "bundleDependencies": [
         "ink",
         "react",
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/identity": "0.1.0-rc.21",
+        "@treeseed/identity": "0.1.0-rc.22",
         "@treeseed/sdk": "0.13.0-rc.110",
         "ink": "^7.1.1",
         "react": "^19.2.8",
@@ -4717,9 +4717,9 @@
       }
     },
     "node_modules/@treeseed/identity": {
-      "version": "0.1.0-rc.21",
-      "resolved": "https://registry.npmjs.org/@treeseed/identity/-/identity-0.1.0-rc.21.tgz",
-      "integrity": "sha512-b9eOSZeukoZtEH76mQN4l0i/AcHtgY/TVYQQxcp7ohhjDtsM2SFiUQBz4rcg73Pol0bw9jjI8tSZ8dyb4LkRkA==",
+      "version": "0.1.0-rc.22",
+      "resolved": "https://registry.npmjs.org/@treeseed/identity/-/identity-0.1.0-rc.22.tgz",
+      "integrity": "sha512-j6Uw8SDNSjXwe+1pxYboKERYoDqKTnQf54imvexwOHaMNtCQF4bDVHkxGjVla7lb7Idmu0vcLeMsiQrJwOSFpg==",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.108",
         "jose": "6.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treeseed/cli",
-  "version": "0.13.0-rc.78",
+  "version": "0.13.0-rc.79",
   "description": "Operator-facing Treeseed CLI package.",
   "license": "Apache-2.0",
   "repository": {
@@ -51,7 +51,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/identity": "0.1.0-rc.21",
+    "@treeseed/identity": "0.1.0-rc.22",
     "@treeseed/sdk": "0.13.0-rc.110",
     "ink": "^7.1.1",
     "react": "^19.2.8",


### PR DESCRIPTION
## Outcome
Pin Identity rc22 for the single exact host payload closure. SDK rc110 remains unchanged.

## Work authority
Closes #179. Continues Platform #497 / Identity #28. User-authorized managed Identity migration.

## Changes
CLI rc79 package/lock alignment only; no command behavior changes.

## Verification
Independent build passes. Both real native browser-PKCE and device credential-store tests pass. Actions must verify the protected candidate and publish unchanged bytes.

## Risk and rollback
Restore the exact prior CLI/Identity composition together. No credential or database changes.