### PR TITLE
Batch final Identity theme fix into unpublished CLI rc79

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@treeseed/identity": "0.1.0-rc.22",
+        "@treeseed/identity": "0.1.0-rc.23",
         "@treeseed/sdk": "0.13.0-rc.110",
         "ink": "^7.1.1",
         "react": "^19.2.8",
@@ -4717,9 +4717,9 @@
       }
     },
     "node_modules/@treeseed/identity": {
-      "version": "0.1.0-rc.22",
-      "resolved": "https://registry.npmjs.org/@treeseed/identity/-/identity-0.1.0-rc.22.tgz",
-      "integrity": "sha512-j6Uw8SDNSjXwe+1pxYboKERYoDqKTnQf54imvexwOHaMNtCQF4bDVHkxGjVla7lb7Idmu0vcLeMsiQrJwOSFpg==",
+      "version": "0.1.0-rc.23",
+      "resolved": "https://registry.npmjs.org/@treeseed/identity/-/identity-0.1.0-rc.23.tgz",
+      "integrity": "sha512-VGcgM+avS9u9JVEczc6suyefwiMHkyjhqPIUYmbr532gKT9it1vg7lzZnF3/yVALjJ+Dd1VyCtyDtmx+E4UqOw==",
       "dependencies": {
         "@treeseed/sdk": "0.13.0-rc.108",
         "jose": "6.2.12",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "release:custody": "node --import tsx ./scripts/packages/release-custody.ts"
   },
   "dependencies": {
-    "@treeseed/identity": "0.1.0-rc.22",
+    "@treeseed/identity": "0.1.0-rc.23",
     "@treeseed/sdk": "0.13.0-rc.110",
     "ink": "^7.1.1",
     "react": "^19.2.8",


### PR DESCRIPTION
## Outcome
Align unpublished rc79 to Identity rc23 before any host activation. Continues #179 and Platform #497.

## Changes
Exact dependency/lock only. rc79 has not been tagged or published; preserve its version while batching the discovered upstream brand inheritance correction.

## Verification
Prior native browser/device tests passed; required Actions verify the final dependency graph and protected candidate before publication. Deployment #681 performs real Keycloak integration.

## Rollback
Restore exact CLI/Identity host composition together; no credential or application schema changes.