### PR TITLE
feat(dev): include managed container diagnostic events

### DIFF
--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -128,7 +128,7 @@ export function usesManagedContainer(target: DevelopmentTarget) {
 	return target.operations.start?.command === 'docker';
 }
 
-async function containerOperation(context: CommandContext, sessionId: string, runtime: DevelopmentRuntime, target: DevelopmentTarget, action: 'start' | 'stop' | 'status') {
+async function containerOperation(context: CommandContext, sessionId: string, runtime: DevelopmentRuntime, target: DevelopmentTarget, action: 'start' | 'stop' | 'status' | 'logs') {
 	return invoke(context, 'local.dev.container', {sessionId,projectId:runtime.project.id,targetId:target.id,action});
 }
 
@@ -463,7 +463,12 @@ async function runDevelopmentUnlocked(invocation: ParsedInvocation, context: Com
 	if (invocation.command.name === 'dev plan') return invoke(context, 'local.dev.plan', { sessionId, selected: [] });
 	if (invocation.command.name === 'dev logs') {
 		const selected = typeof invocation.options.target === 'string' ? invocation.options.target : null;
-		return { logs: Object.entries(state.processes).filter(([key]) => !selected || key === selected).map(([target, processState]) => ({ target, path: processState.log, bytes: existsSync(processState.log) ? statSync(processState.log).size : 0 })) };
+		const logs: unknown[] = Object.entries(state.processes).filter(([key]) => !selected || key === selected).map(([target, processState]) => ({ target, path: processState.log, bytes: existsSync(processState.log) ? statSync(processState.log).size : 0 }));
+		for (const { runtime } of loadRuntimes(state.manifest)) for (const target of runtime.targets) {
+			const key = `${runtime.project.id}.${target.id}`;
+			if (usesManagedContainer(target) && (!selected || selected === key)) logs.push({ target: key, diagnostics: await containerOperation(context, sessionId, runtime, target, 'logs') });
+		}
+		return { logs };
 	}
 	if (invocation.command.name === 'dev rebuild') {
 		return rebuild(invocation, context, state, sessionId);

--- a/tests/unit/command-boundary/development-session.test.ts
+++ b/tests/unit/command-boundary/development-session.test.ts
@@ -89,6 +89,26 @@ test('host runtime development planning is local and status uses the protected m
 	assert.equal(calls.length, 1);
 });
 
+test('development logs include bounded diagnostics for a selected managed container', async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-container-logs-')), file = resolve(root, 'treeseed.package.yaml');
+	const calls: Array<{ handlerId: string; options: { payload: string } }> = [], output: string[] = [];
+	try {
+		writeFileSync(file, manifest.replaceAll('admin', 'api').replace('id: web', 'id: service').replace('command: npm', 'command: docker'));
+		execFileSync('git', ['init', '-b', 'staging'], { cwd: root }); execFileSync('git', ['add', '.'], { cwd: root });
+		execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-m', 'fixture'], { cwd: root });
+		const context = { cwd: root, env: { XDG_STATE_HOME: resolve(root, 'state'), USER: 'tester' }, interactiveUi: false,
+			hostInvoke: async (input: { handlerId: string; options: { payload: string } }) => { calls.push(input); return input.handlerId === 'local.dev.session.start' ? { session: { sessionId: 'dev-logtest' } } : { events: [{ code: '53300' }] }; },
+			write: (value: string) => output.push(value) };
+		assert.equal(await runCommandLine(['dev', 'session', 'start', file, '--json'], context), 0, output.join('\n'));
+		const sessionId = JSON.parse(calls[0]!.options.payload).session.sessionId;
+		output.length = 0;
+		assert.equal(await runCommandLine(['dev', 'logs', '--session', sessionId, '--target', 'api.service', '--json'], context), 0, output.join('\n'));
+		assert.equal(calls[1]?.handlerId, 'local.dev.container');
+		assert.deepEqual(JSON.parse(calls[1]!.options.payload), { sessionId, projectId: 'api', targetId: 'service', action: 'logs' });
+		assert.deepEqual(JSON.parse(output[0]!).result.logs, [{ target: 'api.service', diagnostics: { events: [{ code: '53300' }] } }]);
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('host runtime includes the SDK capacity-provider contracts required by Deployment', () => {
 	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-host-runtime-'));
 	try {


### PR DESCRIPTION
## Outcome
Expose bounded, structured managed API container diagnostics through trsd dev logs.
## Work authority
- Work item / Issue: treeseed-ai/deployment#693
- Proposal / decision: Preserve explicit development selections during Terra activation.
- Assignment / checkpoint: Local Codex agent response acceptance.
- Actor: Codex
- Human authority: User requested activation and real Terra response testing.
- Agent / capacity provider: Codex under user authority
- Exact base ref: 38908cc0b8bcea492c30e6853e3907a0d70b38dc
- Exact head ref: 434bda70a8f9bd74d0394680e12a04cd9053c82b

- [x] Agent-authored under human authority

## Plan
Investigate exact ordinary send failures after successful Terra acceptance. Add registered-target-only diagnostics with bounded Docker tail and a strict metadata whitelist; do not expose messages, SQL or credentials. Preserve Kata null-io.
## Changes and commits
434bda70a8f9bd74d0394680e12a04cd9053c82b adds CLI routing for managed targets and a command-boundary regression test.
## Verification
Command-boundary test, build and TypeScript pass. Live diagnostic acceptance and Actions pending.
## Risk and rollback

No data/schema migration. Root ownership, immutable image, exact selection and snapshot validation remain unchanged. Restore the previous managed host-development generation if activation health fails; never delete a hold or bypass recovery.
## Completion summary
Implementation and focused tests complete; host activation will use the staged source after required checks.
## Submission checklist
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
