### PR TITLE
fix(send): retain diagnostics and fail exit status for failed execution

### DIFF
--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -130,6 +130,11 @@ export async function runCommandLine(argv: string[], overrides: Partial<CommandC
 		const operationResponse = invocation.command.execution.kind === 'operation';
 		if (operationResponse && api?.ok === false) { const failed = failure('policy_blocked', api.code ?? 'control_plane_rejected', api.error ?? 'The control plane rejected the operation.'); print(context, envelope(invocation, false, null, failed), false); return 1; }
 		const result = operationResponse && api && 'payload' in api ? api.payload : response && typeof response === 'object' && 'data' in response ? (response as { data: unknown }).data : response;
+		if (invocation.command.name === 'send' && result && typeof result === 'object' && 'status' in result && result.status === 'failed') {
+			throw Object.assign(new Error('Agent execution failed. The send receipt contains the assignment failure and diagnostics.'), {
+				category: 'provider_unavailable', code: 'communication_execution_failed', partialResult: result,
+			});
+		}
 		print(context, envelope(invocation, true, result)); return 0;
 	} catch (error) {
 		if (context.env.TREESEED_DEBUG_STACK === '1' && error instanceof Error && error.stack) context.write(error.stack, 'stderr');

--- a/tests/unit/command-boundary/communications/send-outcome.test.ts
+++ b/tests/unit/command-boundary/communications/send-outcome.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { runCommandLine } from '../../../src/cli/runtime.ts';
+import { runCommandLine } from '../../../../src/cli/runtime.ts';
 
 for (const status of ['failed', 'complete'] as const) {
 	test(`send preserves the ${status} receipt and reports the execution outcome`, async () => {

--- a/tests/unit/command-boundary/send-outcome.test.ts
+++ b/tests/unit/command-boundary/send-outcome.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runCommandLine } from '../../../src/cli/runtime.ts';
+
+for (const status of ['failed', 'complete'] as const) {
+	test(`send preserves the ${status} receipt and reports the execution outcome`, async () => {
+		const receipt = { sendId: 'send-test', status, targets: [{ invocationId: 'invocation-test',
+			failure: status === 'failed' ? { code: 'sandbox_failed' } : null }] };
+		const output: string[] = [];
+		const exit = await runCommandLine(['send', 'test-channel', '@sdk/architect: Describe the state of the project.',
+			'--team', '11111111-1111-4111-8111-111111111111', '--json'], {
+			interactiveUi: false, operationInvoke: async () => ({ data: receipt }), write: value => output.push(value),
+		});
+		const envelope = JSON.parse(output.at(-1)!);
+		assert.equal(exit, status === 'failed' ? 1 : 0);
+		assert.equal(envelope.ok, status === 'complete');
+		assert.deepEqual(envelope.result, receipt);
+		assert.equal(envelope.error?.code ?? null, status === 'failed' ? 'communication_execution_failed' : null);
+	});
+}


### PR DESCRIPTION
## Outcome
A failed send receipt no longer reports success to callers. Fixes #189.

## Work authority
- Work item / Issue: #189; treeseed-ai/deployment#693
- Proposal / decision: Distinguish HTTP success from agent execution success.
- Assignment / checkpoint: User-requested send reliability repair.
- Actor: adrianwebb
- Human authority: User requested fixing ordinary CLI sends.
- Agent / capacity provider: Codex desktop under user authority.
- Exact base ref: 918b8b5ef31b4791c93a914fa8bd1e70fadccfcd
- Exact head ref: 1253402a79173f741bdf0e9b94d6a793c68e9739
- [x] Agent-authored under human authority

## Plan
Recognize failed terminal send receipts at the common command boundary; keep receipt diagnostics and return nonzero; test successful and failed cases.

## Changes and commits
cc8bd0d9d9b708fcfd0f517f39d993e44e073a59 adds terminal status handling and two regression tests.

## Verification
Two focused command-boundary tests passed. Managed CLI generation 8 activated; Actions pending. 1253402a79173f741bdf0e9b94d6a793c68e9739 groups the test by communication ownership.

## Risk and rollback
No schema, API contract, or credential changes. Only failed sends change exit status. Revert CLI source through managed development if required.

## Completion summary
Bounded implementation complete; Actions and activation remain gates. This does not claim to repair the underlying sandbox failure.

## Submission checklist
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.

