### PR TITLE
fix(send): show failure reason and IDs after response streaming

### DIFF
--- a/src/cli/support/human-renderer.ts
+++ b/src/cli/support/human-renderer.ts
@@ -97,6 +97,20 @@ function renderLibraryRead(result: Record<string, unknown>, options: RenderOptio
 	}).join(`\n\n${ansi(options.color === true, '2;36', '═'.repeat(Math.max(48, Math.min(160, Number(options.width) || 100))))}\n\n`);
 }
 
+function renderCommunicationFailures(result: Record<string, unknown>) {
+	const clean = (value: unknown) => scalar(value).replace(/[\u0000-\u001f\u007f-\u009f]/gu, ' ').slice(0, 512);
+	const targets = Array.isArray(result.targets) ? result.targets : [];
+	return targets.flatMap(value => {
+		if (!value || typeof value !== 'object') return [];
+		const target = value as Record<string, unknown>;
+		if (target.status !== 'failed' && target.status !== 'cancelled') return [];
+		const failure = target.failure && typeof target.failure === 'object' ? target.failure as Record<string, unknown> : {};
+		const capacity = target.capacity && typeof target.capacity === 'object' ? target.capacity as Record<string, unknown> : {};
+		return [`@${clean(target.projectSlug ?? target.projectId)}/${clean(target.agentSlug)}: ${clean(failure.message ?? target.status)}`,
+			`Send: ${clean(result.sendId)}`, `Assignment: ${clean(capacity.assignmentId)}`];
+	}).join('\n');
+}
+
 export function renderHumanCommandResult(value: unknown, options: RenderOptions = {}) {
 	if (!value || typeof value !== 'object') return scalar(value);
 	const envelope = value as { commandPath?: string[]; ok?: boolean; result?: unknown; warnings?: unknown[]; nextActions?: unknown[] };
@@ -135,7 +149,10 @@ export function renderHumanCommandResult(value: unknown, options: RenderOptions 
 		].filter(Boolean).join('\n');
 	}
 	if (path === 'inbox' && result?.interactiveSession === true) return '';
-	if (path === 'send' && result) return result.humanStreamed === true || result.interactiveSession === true ? '' : renderCommunicationResponses(result, options);
+	if (path === 'send' && result) return [
+		result.humanStreamed === true || result.interactiveSession === true ? '' : renderCommunicationResponses(result, options),
+		renderCommunicationFailures(result),
+	].filter(Boolean).join('\n\n');
 	if (path === 'library read' && result) return renderLibraryRead(result, options) || 'No file content was returned.';
 	const rendered = lines(envelope.result);
 	const warnings = Array.isArray(envelope.warnings) && envelope.warnings.length ? [`Warnings: ${envelope.warnings.map(scalar).join('; ')}`] : [];

--- a/tests/unit/command-boundary/communications/send-outcome.test.ts
+++ b/tests/unit/command-boundary/communications/send-outcome.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { runCommandLine } from '../../../../src/cli/runtime.ts';
+import { renderHumanCommandResult } from '../../../../src/cli/support/human-renderer.ts';
 
 for (const status of ['failed', 'complete'] as const) {
 	test(`send preserves the ${status} receipt and reports the execution outcome`, async () => {
@@ -18,3 +19,19 @@ for (const status of ['failed', 'complete'] as const) {
 		assert.equal(envelope.error?.code ?? null, status === 'failed' ? 'communication_execution_failed' : null);
 	});
 }
+
+test('streamed human sends retain failure reason and IDs without duplicating prior responses', () => {
+	const result = { status: 'failed', humanStreamed: true, sendId: 'send-failed',
+		responses: [{ markdown: 'already printed response' }],
+		targets: [{ status: 'failed', projectSlug: 'sdk', agentSlug: 'architect',
+			failure: { message: 'Kata guest exited 1: Guest process failed (ERR_MODULE_NOT_FOUND).' },
+			capacity: { assignmentId: 'assignment-failed' } }],
+	};
+	const rendered = renderHumanCommandResult({ commandPath: ['send'], ok: true, result });
+	assert.match(rendered, /@sdk\/architect: Kata guest exited 1/);
+	assert.match(rendered, /Send: send-failed/);
+	assert.match(rendered, /Assignment: assignment-failed/);
+	assert.doesNotMatch(rendered, /already printed response/);
+	assert.equal(renderHumanCommandResult({ commandPath: ['send'], ok: true,
+		result: { ...result, status: 'complete', targets: [] } }), '');
+});


### PR DESCRIPTION
## Outcome
Human CLI output shows the actual failed target reason plus send and assignment IDs, rather than pointing to an invisible receipt. Fixes #191.

## Work authority
- Work item / Issue: #191; treeseed-ai/deployment#695
- Proposal / decision: Preserve usable user-visible failure diagnostics.
- Assignment / checkpoint: User's repeated exact send failure.
- Actor: adrianwebb
- Human authority: User requested reliable execution and better debugging.
- Agent / capacity provider: Codex desktop under user authority.
- Exact base ref: f5b1d26daae588d5bd5d51ff8b710833be4c04c3
- Exact head ref: 5f3c6f68938aafa18fe8a4c6dd6baf5541d8628d
- [x] Agent-authored under human authority

## Plan
Render failed targets even when responses were streamed, retain response deduplication, bound text and remove control characters, test the user's failure shape.

## Changes and commits
5f3c6f68938aafa18fe8a4c6dd6baf5541d8628d adds compact failure rendering and a streamed receipt regression.

## Verification
Three focused outcome tests pass; source architecture checks pass. Managed CLI rebuild running; Actions pending.

## Risk and rollback
Display-only change; no credential or schema migration. Render bounded failure fields, not protected execution context. Revert through managed development if necessary.

## Completion summary
The previously invisible human failure is implemented; underlying intermittent Kata startup is still tracked separately, not declared fixed.

## Submission checklist
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.
