### PR TITLE
fix(auth): retain session across pre-refresh discovery outages

### DIFF
--- a/src/cli/support/client.ts
+++ b/src/cli/support/client.ts
@@ -31,16 +31,20 @@ export async function createControlPlaneClient(invocation: Pick<ParsedInvocation
 	let client = new ControlPlaneClient({ profile, accessToken: session?.accessToken ?? null, userAgent: 'trsd' });
 	if (requireAuth && session?.refreshToken && (forceRefresh || (session.expiresAt && new Date(session.expiresAt).getTime() <= Date.now() + 30_000))) {
 		const observedRefresh = session.refreshToken;
+		let refreshStarted = false;
 		session = await updateServerSession(profile.serverId, context.env, async current => {
 			if (!current?.accessToken || !current.refreshToken) throw Object.assign(new Error('Session ended before renewal. Log in again.'), { category: 'authentication_required', code: 'authentication_required' });
 			validateIdentitySession(profile,current);
 			const expired = current.expiresAt && new Date(current.expiresAt).getTime() <= Date.now() + 30_000;
 			if (!expired && (!forceRefresh || current.refreshToken !== observedRefresh)) return current;
-			const result = await (await identitySessionClient(profile,current)).refresh(current.refreshToken,current.identity);
+			const identityClient = await identitySessionClient(profile,current);
+			// Discovery has not submitted credentials. Only a refresh attempt can rotate the saved token.
+			refreshStarted = true;
+			const result = await identityClient.refresh(current.refreshToken,current.identity);
 			if (!Number.isFinite(result.tokens.expires_in) || result.tokens.expires_in! <= 0) throw new Error('Identity did not return a bounded token lifetime.');
 			return { ...current, accessToken:result.tokens.access_token, refreshToken:result.tokens.refresh_token ?? current.refreshToken,
 				expiresAt:new Date(Date.now() + result.tokens.expires_in! * 1000).toISOString() };
-		}, true);
+		}, () => refreshStarted);
 		if (!session) throw new Error('Session ended during renewal. Log in again.');
 		client = new ControlPlaneClient({ profile, accessToken: session.accessToken, userAgent: 'trsd' });
 	}

--- a/src/cli/support/server-custody.ts
+++ b/src/cli/support/server-custody.ts
@@ -44,7 +44,7 @@ export async function updateServerSession(
 	serverId: string,
 	env: NodeJS.ProcessEnv,
 	update: (session: ControlPlaneServerSession | null) => Promise<ControlPlaneServerSession | null>,
-	invalidateOnFailure = false,
+	invalidateOnFailure: () => boolean = () => false,
 ) {
 	return withOsCustodyLock(paths(env).custody, async () => {
 		const state = readState(env);
@@ -55,7 +55,7 @@ export async function updateServerSession(
 		};
 		let next: ControlPlaneServerSession | null;
 		try { next = await update(previous); }
-		catch (error) { if (invalidateOnFailure && previous) persist(null); throw error; }
+		catch (error) { if (invalidateOnFailure() && previous) persist(null); throw error; }
 		if (next !== previous) persist(next);
 		return next;
 	});

--- a/tests/unit/command-boundary/auth/identity-renewal-outage.test.ts
+++ b/tests/unit/command-boundary/auth/identity-renewal-outage.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { runCommandLine } from '../../../../src/cli/runtime.ts';
+import { loadServerSession, saveServerSession, saveServerProfile } from '../../../../src/cli/support/server-custody.ts';
+import { apiResource, identityFixture, identityIssuer } from '../../../support/identity-fixture.ts';
+
+for (const failure of ['resource', 'issuer', 'refresh'] as const) test(`renewal ${failure} failure invalidates only after refresh starts`, async context => {
+  const fixture = await identityFixture(); fixture.state.rejectRenewal = true;
+  context.mock.method(globalThis, 'fetch', async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+    const url = String(input);
+    if ((failure === 'resource' && url.includes('oauth-protected-resource')) || (failure === 'issuer' && url.includes('openid-configuration'))) return new Response('Unavailable', { status: 502 });
+    return fixture.transport(input, init);
+  });
+  const root = mkdtempSync(join(tmpdir(), 'treeseed-cli-renewal-')), env = { TREESEED_CONFIG_HOME: root };
+  const output: string[] = [];
+  try {
+    saveServerProfile({ serverId: 'test', label: 'Test', baseUrl: apiResource }, env);
+    await saveServerSession({ serverId: 'test', audience: apiResource, identity: { issuer: identityIssuer, subject: 'subject' }, clientId: 'trsd', scopes: ['openid'],
+      accessToken: 'synthetic-access', refreshToken: 'synthetic-refresh', expiresAt: '2020-01-01T00:00:00.000Z', activeTeam: { id: 'team', slug: 'team', name: 'Team' } }, env);
+    const before = loadServerSession('test', env);
+    const exit = await runCommandLine(['auth', 'status', '--server', 'test', '--json'], { env, interactiveUi: false, write: value => output.push(value) });
+    assert.notEqual(exit, 0);
+    if (failure === 'refresh') { assert.equal(fixture.state.tokenCalls, 1); assert.equal(loadServerSession('test', env), null); }
+    else { assert.equal(fixture.state.tokenCalls, 0); assert.deepEqual(loadServerSession('test', env), before); }
+    assert.equal(output.join('').includes('synthetic-refresh'), false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});

--- a/tests/unit/command-boundary/server-custody.test.ts
+++ b/tests/unit/command-boundary/server-custody.test.ts
@@ -80,7 +80,7 @@ test('session transactions preserve concurrent server and team edits and invalid
 		await Promise.all([renewal, selection]);
 		assert.equal(loadServerSession('one', env)?.refreshToken, 'rotated');
 		assert.equal(loadServerSession('one', env)?.activeTeam?.id, 'team');
-		await assert.rejects(updateServerSession('one', env, async () => { throw new Error('ambiguous renewal'); }, true), /ambiguous renewal/);
+		await assert.rejects(updateServerSession('one', env, async () => { throw new Error('ambiguous renewal'); }, () => true), /ambiguous renewal/);
 		assert.equal(loadServerSession('one', env), null);
 		assert.equal(loadServerSession('two', env)?.accessToken, 'old');
 		await assert.rejects(updateServerSession('two', env, async () => { throw new Error('invalid edit'); }), /invalid edit/);
@@ -107,7 +107,7 @@ test('logout waits for renewal and a queued renewal cannot resurrect a removed s
 		await assert.rejects(updateServerSession('one', env, async current => {
 			assert.equal(current, null);
 			throw new Error('session ended');
-		}, true), /session ended/);
+		}, () => true), /session ended/);
 		assert.equal(loadServerSession('one', env), null);
 	} finally { rmSync(root, {recursive:true, force:true}); }
 });


### PR DESCRIPTION
## Outcome
Do not erase a valid encrypted session when API/issuer discovery fails before renewal submits a refresh token.

## Work authority
- Work item / Issue: Fixes #193
- Proposal / decision: Repair local acceptance interruption under Platform #501.
- Assignment / checkpoint: Session renewal reliability.
- Actor: adrianwebb
- Human authority: adrianwebb
- Agent / capacity provider: Codex under human authority
- Exact base ref: 3127d760838a2bec326cfc73ae30e201203bfff6
- Exact head ref: 251a50e713a615ea333ec9aad3320b7f5b3e3593
- [x] Agent-authored under human authority

## Plan
Keep discovery and renewal within the serialized session transaction. Begin failure invalidation only immediately before refresh invocation.

## Changes and commits
251a50e introduces a transaction invalidation predicate. Unavailable discovery preserves the session and team. Ambiguous refresh continues to clear the selected session. No alternate credential storage or authentication bypass.

## Verification
Three synthetic resource/issuer/refresh outage tests pass; all four existing custody tests passed in the preceding focused run. Strict TypeScript and file architecture pass. CLI distribution rebuilt without touching unrelated generated docs/schema edits. Actions required on exact head.

## Risk and rollback
Session invalidation behavior is deliberately unchanged once refresh begins, including uncertain token rotation. Revert this commit to restore prior behavior. Already-erased credentials are not recovered; browser sign-in remains required.

## Completion summary
The identified pre-refresh outage defect is fixed. This does not assert successful live source-enabled agent execution.

## Submission checklist
- [x] The change is bounded to the stated work item and target repository.
- [x] Exact base and head refs are recorded and the branch is ready for review.
- [x] Verification and compatibility evidence are recorded above.
- [x] No plaintext secrets, credentials, machine state, or unrelated residue are included.
- [x] Plan, status, commits, and completion summary form a complete durable record.
- [x] Rollback or recovery steps are documented and executable.