### PR TITLE
Make source overlays manager-readable

### DIFF
--- a/src/cli/commands/development-support/host-dependencies.ts
+++ b/src/cli/commands/development-support/host-dependencies.ts
@@ -4,6 +4,13 @@ import { dirname, resolve, sep } from 'node:path';
 type Package = { dependencies?: Record<string, string>; optionalDependencies?: Record<string, string>; treeseed?: { hostRuntimeDependencies?: string[] } };
 const read = (root: string): Package => JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
 
+function isCompletePackageOverlay(path: string, name: string) {
+	const marker = `${sep}.treeseed${sep}cache${sep}development-sessions${sep}`;
+	return path.includes(marker) && new RegExp(`${sep}package${sep}generation-[1-9][0-9]*$`, 'u').test(path)
+		&& existsSync(resolve(path, 'dist', '.treeseed-build-complete.json'))
+		&& (read(path) as Package & { name?: string }).name === name;
+}
+
 /** Deployment declares its runtime roots; npm's installed graph supplies their closure. */
 export function hostDependencyRoots(worktree: string): string[] {
 	const root = realpathSync(worktree), manifest = read(root);
@@ -19,11 +26,12 @@ export function hostDependencyRoots(worktree: string): string[] {
 			cursor = dirname(cursor);
 		}
 		if (!selected) { if (optional) return; throw new Error(`Host runtime dependency is missing: ${name}`); }
-		if (realpathSync(selected) !== selected) throw new Error('Host runtime dependency contains a symbolic link.');
+		const resolved = realpathSync(selected), overlay = resolved !== selected && isCompletePackageOverlay(resolved, name);
+		if (resolved !== selected && !overlay) throw new Error('Host runtime dependency contains a symbolic link.');
 		if (found.has(selected)) return;
 		found.add(selected);
 		const pkg = read(selected);
-		for (const dependency of Object.keys({ ...pkg.dependencies, ...pkg.optionalDependencies })) visit(dependency, selected, dependency in (pkg.optionalDependencies ?? {}));
+		for (const dependency of Object.keys({ ...pkg.dependencies, ...pkg.optionalDependencies })) visit(dependency, overlay ? root : selected, dependency in (pkg.optionalDependencies ?? {}));
 	}
 	for (const name of names) {
 		if (!(name in (manifest.dependencies ?? {}))) throw new Error('Host runtime root must be a production dependency.');

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -221,7 +221,7 @@ async function useTargets(invocation: Pick<ParsedInvocation, 'arguments' | 'opti
 			if (selection.projectId === 'cli' && selection.targetId === 'package') selectDevelopmentCli(context.env, null);
 		} else {
 			if (usesManagedContainer(target) && managedContainerAlreadyReady(await containerOperation(context, sessionId, runtime, target, 'status'), sessionId, target.id)) {
-				await invoke(context, 'local.dev.use', { sessionId, ...selection, ...(target.endpoints[0] ? { port: target.endpoints[0].port } : {}) });
+				await invoke(context, 'local.dev.use', { sessionId, ...selection, ...(!usesManagerBuild(target) && target.endpoints[0] ? { port: target.endpoints[0].port } : {}) });
 				continue;
 			}
 			const resolved = await invoke(context, 'local.dev.environment', { sessionId, projectId: selection.projectId, targetId: selection.targetId }) as { environment?: NodeJS.ProcessEnv };
@@ -246,7 +246,7 @@ async function useTargets(invocation: Pick<ParsedInvocation, 'arguments' | 'opti
 				if (selection.projectId === 'cli' && selection.targetId === 'package') selectDevelopmentCli(context.env, { entrypoint: resolve(overlayRoot, 'current', 'dist', 'cli', 'main.js') });
 			} else if (!usesManagedContainer(target)) await waitForDirectReadiness(target, target.ready.kind === 'process' ? target.ready.graceSeconds : target.ready.timeoutSeconds, state, `${runtime.project.id}.${target.id}`);
 		}
-		await invoke(context, 'local.dev.use', { sessionId, ...selection, ...(selection.mode !== 'released' && target.endpoints[0] ? { port: target.endpoints[0].port } : {}) });
+		await invoke(context, 'local.dev.use', { sessionId, ...selection, ...(selection.mode !== 'released' && !usesManagerBuild(target) && target.endpoints[0] ? { port: target.endpoints[0].port } : {}) });
 	}
 	saveState(state, context.env); return invoke(context, 'local.dev.status', { sessionId, all: false });
 }
@@ -314,7 +314,7 @@ async function verifyCandidate(invocation: ParsedInvocation, context: CommandCon
 
 async function markRebuilt(context: CommandContext, sessionId: string, projectId: string, targetId: string, mode: 'candidate' | 'live', target: DevelopmentTarget) {
 	await invoke(context, 'local.dev.rebuild', { sessionId, projectId, targetId });
-	await invoke(context, 'local.dev.use', { sessionId, projectId, targetId, mode, ...(target.endpoints[0] ? { port: target.endpoints[0].port } : {}) });
+	await invoke(context, 'local.dev.use', { sessionId, projectId, targetId, mode, ...(!usesManagerBuild(target) && target.endpoints[0] ? { port: target.endpoints[0].port } : {}) });
 }
 
 async function rebuildPackage(input: { state: LocalSessionState; runtime: DevelopmentRuntime; target: DevelopmentTarget; worktree: string; mode: 'candidate' | 'live'; context: CommandContext }) {

--- a/src/cli/development/package-overlay-sync.ts
+++ b/src/cli/development/package-overlay-sync.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, symlinkSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, symlinkSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { createHash } from 'node:crypto';
@@ -21,7 +21,7 @@ function signature(root: string, outputs: string[], marker: string) {
 
 function publish(root: string, overlayRoot: string, outputs: string[], generation: number) {
 	const target = resolve(overlayRoot, `generation-${generation}`), next = resolve(overlayRoot, '.current-next'), current = resolve(overlayRoot, 'current');
-	rmSync(target, { recursive: true, force: true }); mkdirSync(target, { recursive: true, mode: 0o700 });
+	rmSync(target, { recursive: true, force: true }); mkdirSync(target, { recursive: true, mode: 0o750 }); chmodSync(target, 0o750);
 	cpSync(resolve(root, 'package.json'), resolve(target, 'package.json'));
 	if (existsSync(resolve(root, 'node_modules'))) symlinkSync(resolve(root, 'node_modules'), resolve(target, 'node_modules'), 'dir');
 	for (const output of outputs) {
@@ -37,7 +37,13 @@ function publish(root: string, overlayRoot: string, outputs: string[], generatio
 }
 
 export async function synchronizePackageOverlay(root: string, overlayRoot: string, outputs: string[], marker: string, intervalMs = 250) {
-	mkdirSync(overlayRoot, { recursive: true, mode: 0o700 });
+	const relativeRoot = relative(root, overlayRoot);
+	if (relativeRoot.startsWith('..') || relativeRoot === '') throw new Error('Package overlay root must be inside its source checkout.');
+	let directory = root;
+	for (const segment of relativeRoot.split('/')) {
+		directory = resolve(directory, segment);
+		mkdirSync(directory, { recursive: true, mode: 0o750 }); chmodSync(directory, 0o750);
+	}
 	let observed = '', stable = '', published = '', generation = 0, lastFailure = '';
 	while (true) {
 		try {

--- a/tests/unit/command-boundary/development-session.test.ts
+++ b/tests/unit/command-boundary/development-session.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import test from 'node:test';
@@ -184,6 +184,8 @@ test('package synchronizer launches the CLI development module and publishes a c
 		const deadline = Date.now() + 2_000;
 		while (!existsSync(resolve(overlay, 'current')) && Date.now() < deadline) await new Promise((accept) => setTimeout(accept, 25));
 		assert.equal(existsSync(resolve(overlay, 'current', 'dist/index.js')), true, readFileSync(state.processes['overlay-sync.sdk.package']!.log, 'utf8'));
+		assert.equal(statSync(overlay).mode & 0o050, 0o050, 'manager-side consumers require group traversal');
+		assert.equal(statSync(resolve(overlay, 'current')).mode & 0o050, 0o050, 'completed generations require group traversal');
 	} finally {
 		await stopProcess(state, 'overlay-sync.sdk.package');
 		rmSync(root, { recursive: true, force: true }); rmSync(stateRoot, { recursive: true, force: true });

--- a/tests/unit/command-boundary/development/host-dependencies.test.ts
+++ b/tests/unit/command-boundary/development/host-dependencies.test.ts
@@ -20,3 +20,20 @@ test('host custody includes nested production dependencies but not development-o
 		assert.throws(() => hostDependencyRoots(root), /symbolic link/);
 	} finally { rmSync(root, { recursive: true }); }
 });
+
+test('host custody accepts a complete local package generation while resolving its closure from the host worktree', () => {
+	const root = mkdtempSync(join(tmpdir(), 'host-overlay-'));
+	const pkg = (path: string, data: unknown) => { mkdirSync(path, { recursive: true }); writeFileSync(join(path, 'package.json'), JSON.stringify(data)); };
+	try {
+		pkg(root, { dependencies: { '@treeseed/sdk': '1' }, treeseed: { hostRuntimeDependencies: ['@treeseed/sdk'] } });
+		const generation = join(root, 'sdk/.treeseed/cache/development-sessions/dev-test/package/generation-1');
+		pkg(generation, { name: '@treeseed/sdk', dependencies: { zod: '1' } });
+		mkdirSync(join(generation, 'dist')); writeFileSync(join(generation, 'dist/.treeseed-build-complete.json'), '{}');
+		pkg(join(root, 'node_modules/zod'), { name: 'zod' });
+		mkdirSync(join(root, 'node_modules/@treeseed'), { recursive: true });
+		symlinkSync(generation, join(root, 'node_modules/@treeseed/sdk'));
+		assert.deepEqual(hostDependencyRoots(root), [join(root, 'node_modules/@treeseed/sdk'), join(root, 'node_modules/zod')]);
+		rmSync(join(generation, 'dist/.treeseed-build-complete.json'));
+		assert.throws(() => hostDependencyRoots(root), /symbolic link/);
+	} finally { rmSync(root, { recursive: true }); }
+});

--- a/tests/unit/command-boundary/development/lifecycle-entrypoints.test.ts
+++ b/tests/unit/command-boundary/development/lifecycle-entrypoints.test.ts
@@ -16,14 +16,18 @@ test('boot resume and manual use re-read state under the same lifecycle lock', {
         session: { sessionId, status: 'active', repositories: [{ projectId: 'api', worktree: root }],
             targets: [{ projectId: 'api', targetId: 'operations-runner', mode: 'candidate', generation: 0, health: 'pending' }] },
         runtimes: [{ project: { id: 'api' }, targets: [{ id: 'operations-runner', kind: 'rebuild-restart', executionCustody: 'manager',
-            operations: { start: { command: 'manager-runtime' } }, dependencies: [], endpoints: [], ready: { kind: 'process', graceSeconds: 0 } }] }],
+            operations: { start: { command: 'manager-runtime' } }, dependencies: [], endpoints: [{ id: 'http', protocol: 'http', port: 4000 }], ready: { kind: 'process', graceSeconds: 0 } }] }],
     };
     let started = false, starts = 0;
     const context = {
         cwd: root, env,
         hostInvoke: async (request: { handlerId: string; options: { payload?: unknown } }) => {
             const payload = JSON.parse(String(request.options.payload));
-            if (request.handlerId === 'local.dev.status' || request.handlerId === 'local.dev.use') return record;
+            if (request.handlerId === 'local.dev.status') return record;
+            if (request.handlerId === 'local.dev.use') {
+                assert.equal(payload.port, undefined, 'Manager-custody targets must not receive redundant host-port readiness probes');
+                return record;
+            }
             if (request.handlerId === 'local.dev.environment') return { environment: {} };
             if (request.handlerId === 'local.dev.container' && payload.action === 'status') return started
                 ? { registered: true, state: JSON.stringify({ Name: 'treeseed-dev-test-api-operations-runner', State: 'running', Health: 'healthy' }) }


### PR DESCRIPTION
Closes #206

Package overlay generations now retain owner write access while granting checkout-group traversal required by manager-owned development containers. The focused synchronizer test passes and asserts both the overlay root and completed generation custody. No release is published.