### PR TITLE
Make development overlay custody exclusive

### DIFF
--- a/src/cli/commands/development-support/lifecycle.ts
+++ b/src/cli/commands/development-support/lifecycle.ts
@@ -1,6 +1,16 @@
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { withOsCustodyLock } from '../../support/server-custody.js';
 import { developmentStateRoot } from '../development-cli-selection.js';
+import { ownsDevelopmentProcess } from './process-identity.js';
+
+export function assertNoSelectedDevelopmentCustody(env: NodeJS.ProcessEnv) {
+	const selectedState = resolve(developmentStateRoot(env), 'current.json');
+	if (!existsSync(selectedState)) return;
+	const selected = JSON.parse(readFileSync(selectedState, 'utf8')) as { sessionId: string; processes?: Record<string, Parameters<typeof ownsDevelopmentProcess>[0]>; overlays?: unknown[] };
+	const ownsProcesses = Object.values(selected.processes ?? {}).some((entry) => ownsDevelopmentProcess(entry, selected.sessionId));
+	if (ownsProcesses || (selected.overlays ?? []).length > 0) throw new Error(`Development session ${selected.sessionId} still owns local processes or package overlays; stop or recover it before starting another session.`);
+}
 
 /** Shared builds and current.json cross session boundaries. Lock the Linux
  * operator's lifecycle, not a time-limited development selection. Deployment

--- a/src/cli/commands/development-support/overlays.ts
+++ b/src/cli/commands/development-support/overlays.ts
@@ -27,6 +27,14 @@ export async function stopProcesses(state: OverlaySessionState) {
 export function restoreOverlays(state: OverlaySessionState, projectId?: string, removeGenerations = true) {
 	const retained: OverlaySessionState['overlays'] = [];
 	for (const overlay of state.overlays ?? []) {
+		if (projectId && overlay.projectId !== projectId) continue;
+		if (overlay.backup) {
+			try {
+				if (lstatSync(overlay.backup).isSymbolicLink()) throw new Error(`Development overlay backup is not a release directory: ${overlay.backup}.`);
+			} catch (error) { if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error; }
+		}
+	}
+	for (const overlay of state.overlays ?? []) {
 		if (projectId && overlay.projectId !== projectId) { retained.push(overlay); continue; }
 		if (existsSync(overlay.link) || (() => { try { lstatSync(overlay.link); return true; } catch { return false; } })()) rmSync(overlay.link, { recursive: true, force: true });
 		if (overlay.backup && existsSync(overlay.backup)) renameSync(overlay.backup, overlay.link);
@@ -60,6 +68,14 @@ export function installPackageOverlay(state: OverlaySessionState, record: { sess
 		const backup = `${link}.treeseed-release-${state.sessionId}`;
 		let owned = false;
 		try { owned = lstatSync(link).isSymbolicLink() && resolve(dirname(link), readlinkSync(link)) === resolve(overlayRoot, 'current'); } catch { /* No existing link. */ }
+		if (!owned) {
+			try {
+				if (lstatSync(link).isSymbolicLink()) throw new Error(`Another development overlay blocks ${link}; stop or recover its owning session first.`);
+			} catch (error) { if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error; }
+		}
+		try {
+			if (lstatSync(backup).isSymbolicLink()) throw new Error(`Development overlay backup is not a release directory: ${backup}.`);
+		} catch (error) { if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error; }
 		if (existsSync(backup) && !owned) throw new Error(`Stale development overlay backup blocks ${link}.`);
 		planned.push({ link, backup, owned });
 	}

--- a/src/cli/commands/development-support/runtime-loader.ts
+++ b/src/cli/commands/development-support/runtime-loader.ts
@@ -1,0 +1,50 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { developmentRuntimeSchema } from '@treeseed/sdk/development';
+import { parse as parseYaml } from 'yaml';
+
+export interface ProjectSelection { manifest: string; worktree?: string; targets?: Array<{ id: string; mode: 'released' | 'candidate' | 'live' }> }
+
+function projectSelections(file: string): ProjectSelection[] {
+	const root = dirname(file), document = parseYaml(readFileSync(file, 'utf8')) as Record<string, unknown>;
+	if (document.development) return [{ manifest: file, worktree: root }];
+	if (!Array.isArray(document.projects) || document.projects.length === 0) throw new Error('Development session manifest requires a non-empty projects array.');
+	return document.projects.map((project) => {
+		if (!project || typeof project !== 'object' || Array.isArray(project)) throw new Error('Development project selection must be an object.');
+		const input = project as Record<string, unknown>;
+		if (typeof input.manifest !== 'string') throw new Error('Development project selection requires a manifest path.');
+		const manifest = isAbsolute(input.manifest) ? input.manifest : resolve(root, input.manifest);
+		const worktree = typeof input.worktree === 'string' ? (isAbsolute(input.worktree) ? input.worktree : resolve(root, input.worktree)) : dirname(manifest);
+		return { manifest, worktree, ...(Array.isArray(input.targets) ? { targets: input.targets as ProjectSelection['targets'] } : {}) };
+	});
+}
+
+async function sourceSchema(selections: ProjectSelection[], prepare: boolean) {
+	const sdk = selections.find((selection) => {
+		const document = parseYaml(readFileSync(selection.manifest, 'utf8')) as { development?: { project?: { id?: unknown; repository?: unknown } } };
+		return document.development?.project?.id === 'sdk' && document.development.project.repository === 'treeseed-ai/sdk';
+	});
+	if (!sdk) return developmentRuntimeSchema;
+	const worktree = sdk.worktree ?? dirname(sdk.manifest), packagePath = resolve(worktree, 'package.json');
+	const packageDocument = JSON.parse(readFileSync(packagePath, 'utf8')) as { name?: unknown; scripts?: { ['build:dist']?: unknown } };
+	if (packageDocument.name !== '@treeseed/sdk' || typeof packageDocument.scripts?.['build:dist'] !== 'string') throw new Error('The selected SDK source is not a buildable @treeseed/sdk worktree.');
+	if (prepare) {
+		const result = spawnSync('npm', ['run', 'build:dist'], { cwd: worktree, env: process.env, stdio: 'inherit', timeout: 900_000 });
+		if (result.status !== 0) throw new Error('The selected SDK source contract could not be built.');
+	}
+	const entrypoint = resolve(worktree, 'dist/development/index.js');
+	if (!existsSync(entrypoint)) throw new Error('The selected SDK source contract is not built. Run development session start without --plan to prepare it.');
+	const module = await import(`${pathToFileURL(entrypoint).href}?source=${statSync(entrypoint).mtimeMs}`) as { developmentRuntimeSchema?: typeof developmentRuntimeSchema };
+	if (!module.developmentRuntimeSchema?.parse) throw new Error('The selected SDK source does not export its development runtime contract.');
+	return module.developmentRuntimeSchema;
+}
+
+export async function loadDevelopmentRuntimes(file: string, prepareLocalSdk = false) {
+	const selections = projectSelections(file), schema = await sourceSchema(selections, prepareLocalSdk);
+	return selections.map((selection) => {
+		const document = parseYaml(readFileSync(selection.manifest, 'utf8')) as { development?: unknown };
+		return { selection, runtime: schema.parse(document.development) };
+	});
+}

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, readlinkSync, readdirSync, renameSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { developmentCandidateSchema, developmentRuntimeSchema, type DevelopmentRuntime, type DevelopmentTarget } from '@treeseed/sdk/development';
 import { parse as parseYaml } from 'yaml';
 import type { CommandContext, ParsedInvocation } from '../types.js';
@@ -81,10 +81,31 @@ function projectSelections(file: string): ProjectSelection[] {
 	});
 }
 
-function loadRuntimes(file: string) {
-	return projectSelections(file).map((selection) => {
+async function localDevelopmentRuntimeSchema(selections: ProjectSelection[], prepare: boolean) {
+	const sdk = selections.find((selection) => {
+		const document = parseYaml(readFileSync(selection.manifest, 'utf8')) as { development?: { project?: { id?: unknown; repository?: unknown } } };
+		return document.development?.project?.id === 'sdk' && document.development.project.repository === 'treeseed-ai/sdk';
+	});
+	if (!sdk) return developmentRuntimeSchema;
+	const worktree = sdk.worktree ?? dirname(sdk.manifest), packagePath = resolve(worktree, 'package.json');
+	const packageDocument = JSON.parse(readFileSync(packagePath, 'utf8')) as { name?: unknown; scripts?: { ['build:dist']?: unknown } };
+	if (packageDocument.name !== '@treeseed/sdk' || typeof packageDocument.scripts?.['build:dist'] !== 'string') throw new Error('The selected SDK source is not a buildable @treeseed/sdk worktree.');
+	if (prepare) {
+		const result = spawnSync('npm', ['run', 'build:dist'], { cwd: worktree, env: process.env, stdio: 'inherit', timeout: 900_000 });
+		if (result.status !== 0) throw new Error('The selected SDK source contract could not be built.');
+	}
+	const entrypoint = resolve(worktree, 'dist/development/index.js');
+	if (!existsSync(entrypoint)) throw new Error('The selected SDK source contract is not built. Run development session start without --plan to prepare it.');
+	const module = await import(`${pathToFileURL(entrypoint).href}?source=${statSync(entrypoint).mtimeMs}`) as { developmentRuntimeSchema?: typeof developmentRuntimeSchema };
+	if (!module.developmentRuntimeSchema?.parse) throw new Error('The selected SDK source does not export its development runtime contract.');
+	return module.developmentRuntimeSchema;
+}
+
+async function loadRuntimes(file: string, prepareLocalSdk = false) {
+	const selections = projectSelections(file), schema = await localDevelopmentRuntimeSchema(selections, prepareLocalSdk);
+	return selections.map((selection) => {
 		const document = parseYaml(readFileSync(selection.manifest, 'utf8')) as { development?: unknown };
-		return { selection, runtime: developmentRuntimeSchema.parse(document.development) };
+		return { selection, runtime: schema.parse(document.development) };
 	});
 }
 
@@ -187,14 +208,15 @@ async function waitForDirectReadiness(target: DevelopmentTarget, timeoutSeconds:
 }
 
 async function startSession(invocation: ParsedInvocation, context: CommandContext) {
-	const manifest = resolve(context.cwd, invocation.arguments[0]!); const projects = loadRuntimes(manifest);
+	const manifest = resolve(context.cwd, invocation.arguments[0]!);
+	if (invocation.options.plan !== true) assertNoSelectedDevelopmentCustody(context.env);
+	const projects = await loadRuntimes(manifest, invocation.options.plan !== true);
 	const now = new Date();
 	const sessionId = `dev-${randomUUID().slice(0, 12)}`;
 	const targets = projects.flatMap(({ selection, runtime }) => (selection.targets ?? runtime.targets.map((target) => ({ id: target.id, mode: target.kind === 'rebuild-restart' ? 'candidate' as const : 'released' as const }))).map((target) => ({ projectId: runtime.project.id, targetId: target.id, mode: target.mode, generation: 0, health: target.mode === 'released' ? 'ready' as const : 'pending' as const })));
 	const leases = projects.flatMap(({ selection, runtime }) => runtime.targets.filter((target) => targets.some((entry) => entry.projectId === runtime.project.id && entry.targetId === target.id && entry.mode !== 'released')).flatMap((target) => target.endpoints.filter((endpoint) => endpoint.canonicalAlias).map((endpoint) => ({ kind: 'alias' as const, resource: endpoint.canonicalAlias!, acquiredAt: now.toISOString() }))));
 	const session = { schemaVersion: 'treeseed.development-session/v2' as const, sessionId, actor: String(invocation.options.actor ?? context.env.USER ?? 'local-developer'), hostId: 'local-host', createdAt: now.toISOString(), status: 'planning' as const, repositories: projects.map(({ selection, runtime }) => repositoryClosure(runtime, selection.worktree!)), targets, leases, restoredReceiptId: null, blockers: [] };
 	if (invocation.options.plan === true) return { session, runtimes: projects.map(({ runtime }) => runtime), mutation: false };
-	assertNoSelectedDevelopmentCustody(context.env);
 	const result = await invoke(context, 'local.dev.session.start', { session, runtimes: projects.map(({ runtime }) => runtime) });
 	saveState({ sessionId, manifest, processes: {}, overlays: [], candidates: [] }, context.env); return result;
 }
@@ -472,7 +494,7 @@ async function runDevelopmentUnlocked(invocation: ParsedInvocation, context: Com
 		if (invocation.options.plan === true) return { sessionId, restore: true, mutation: false };
 		const running = await stopProcesses(state);
 		const active = new Set(running.map((entry) => `${entry.projectId}.${entry.targetId}`));
-		for (const { selection, runtime } of loadRuntimes(state.manifest)) for (const target of runtime.targets) {
+		for (const { selection, runtime } of await loadRuntimes(state.manifest)) for (const target of runtime.targets) {
 			if (usesManagedContainer(target)) await containerOperation(context, sessionId, runtime, target, 'stop');
 			else if (active.has(`${runtime.project.id}.${target.id}`) && target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, selection.worktree!, 'released', context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'session' });
 		}
@@ -483,7 +505,7 @@ async function runDevelopmentUnlocked(invocation: ParsedInvocation, context: Com
 	if (invocation.command.name === 'dev logs') {
 		const selected = typeof invocation.options.target === 'string' ? invocation.options.target : null;
 		const logs: unknown[] = Object.entries(state.processes).filter(([key]) => !selected || key === selected).map(([target, processState]) => ({ target, path: processState.log, bytes: existsSync(processState.log) ? statSync(processState.log).size : 0 }));
-		for (const { runtime } of loadRuntimes(state.manifest)) for (const target of runtime.targets) {
+		for (const { runtime } of await loadRuntimes(state.manifest)) for (const target of runtime.targets) {
 			const key = `${runtime.project.id}.${target.id}`;
 			if (usesManagedContainer(target) && (!selected || selected === key)) logs.push({ target: key, diagnostics: await containerOperation(context, sessionId, runtime, target, 'logs') });
 		}

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -14,7 +14,7 @@ import { runHostDevelopment } from './development-support/host-runtime.js';
 import { applyDevelopmentRecovery, planDevelopmentRecovery } from './development-support/recovery.js';
 import { ownsDevelopmentProcess, processIdentity } from './development-support/process-identity.js';
 import { developmentBootOrder } from './development-support/boot-order.js';
-import { managedContainerAlreadyReady, withDevelopmentLifecycle } from './development-support/lifecycle.js';
+import { assertNoSelectedDevelopmentCustody, managedContainerAlreadyReady, withDevelopmentLifecycle } from './development-support/lifecycle.js';
 export { relativeOverlayTarget, startPackageSynchronizer, stopProcess, waitForNewPackageOverlay } from './development-support/overlays.js';
 export { developmentCliEntrypointPath, selectDevelopmentCli } from './development-cli-selection.js';
 
@@ -194,14 +194,7 @@ async function startSession(invocation: ParsedInvocation, context: CommandContex
 	const leases = projects.flatMap(({ selection, runtime }) => runtime.targets.filter((target) => targets.some((entry) => entry.projectId === runtime.project.id && entry.targetId === target.id && entry.mode !== 'released')).flatMap((target) => target.endpoints.filter((endpoint) => endpoint.canonicalAlias).map((endpoint) => ({ kind: 'alias' as const, resource: endpoint.canonicalAlias!, acquiredAt: now.toISOString() }))));
 	const session = { schemaVersion: 'treeseed.development-session/v2' as const, sessionId, actor: String(invocation.options.actor ?? context.env.USER ?? 'local-developer'), hostId: 'local-host', createdAt: now.toISOString(), status: 'planning' as const, repositories: projects.map(({ selection, runtime }) => repositoryClosure(runtime, selection.worktree!)), targets, leases, restoredReceiptId: null, blockers: [] };
 	if (invocation.options.plan === true) return { session, runtimes: projects.map(({ runtime }) => runtime), mutation: false };
-	const selectedState = statePath(context.env);
-	if (existsSync(selectedState)) {
-		const selected = JSON.parse(readFileSync(selectedState, 'utf8')) as LocalSessionState;
-		const ownsProcesses = Object.values(selected.processes ?? {}).some((entry) => ownsDevelopmentProcess(entry, selected.sessionId));
-		if (ownsProcesses || (selected.overlays ?? []).length > 0) {
-			throw new Error(`Development session ${selected.sessionId} still owns local processes or package overlays; stop or recover it before starting another session.`);
-		}
-	}
+	assertNoSelectedDevelopmentCustody(context.env);
 	const result = await invoke(context, 'local.dev.session.start', { session, runtimes: projects.map(({ runtime }) => runtime) });
 	saveState({ sessionId, manifest, processes: {}, overlays: [], candidates: [] }, context.env); return result;
 }

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -2,9 +2,8 @@ import { createHash, randomUUID } from 'node:crypto';
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { closeSync, existsSync, lstatSync, mkdirSync, openSync, readFileSync, readlinkSync, readdirSync, renameSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
 import { basename, dirname, isAbsolute, relative, resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { developmentCandidateSchema, developmentRuntimeSchema, type DevelopmentRuntime, type DevelopmentTarget } from '@treeseed/sdk/development';
-import { parse as parseYaml } from 'yaml';
+import { fileURLToPath } from 'node:url';
+import { developmentCandidateSchema, type DevelopmentRuntime, type DevelopmentTarget } from '@treeseed/sdk/development';
 import type { CommandContext, ParsedInvocation } from '../types.js';
 import { invokeLocalHostManager } from '../support/host-client.js';
 import { developmentStateRoot, selectDevelopmentCli } from './development-cli-selection.js';
@@ -15,6 +14,7 @@ import { applyDevelopmentRecovery, planDevelopmentRecovery } from './development
 import { ownsDevelopmentProcess, processIdentity } from './development-support/process-identity.js';
 import { developmentBootOrder } from './development-support/boot-order.js';
 import { assertNoSelectedDevelopmentCustody, managedContainerAlreadyReady, withDevelopmentLifecycle } from './development-support/lifecycle.js';
+import { loadDevelopmentRuntimes } from './development-support/runtime-loader.js';
 export { relativeOverlayTarget, startPackageSynchronizer, stopProcess, waitForNewPackageOverlay } from './development-support/overlays.js';
 export { developmentCliEntrypointPath, selectDevelopmentCli } from './development-cli-selection.js';
 
@@ -27,7 +27,6 @@ interface LocalSessionState {
 	candidates: string[];
 }
 
-interface ProjectSelection { manifest: string; worktree?: string; targets?: Array<{ id: string; mode: 'released' | 'candidate' | 'live' }> }
 interface DevelopmentStatusRecord {
 	session: {
 		targets: Array<{ projectId: string; targetId: string; mode: 'released' | 'candidate' | 'live'; generation: number; health?: string }>;
@@ -67,47 +66,6 @@ function repositoryClosure(runtime: DevelopmentRuntime, worktree: string, exclud
 	return { projectId: runtime.project.id, repository: runtime.project.repository, worktree, commit: git(worktree, ['rev-parse', 'HEAD']), branch, dirty: Boolean(status), dirtyDigest: status ? sha256(`${status}\n${git(worktree, ['diff', '--binary', 'HEAD', ...pathspec])}`) : null, recipeDigest: sha256(JSON.stringify(runtime)) };
 }
 
-function projectSelections(file: string): ProjectSelection[] {
-	const root = dirname(file), document = parseYaml(readFileSync(file, 'utf8')) as Record<string, unknown>;
-	if (document.development) return [{ manifest: file, worktree: root }];
-	if (!Array.isArray(document.projects) || document.projects.length === 0) throw new Error('Development session manifest requires a non-empty projects array.');
-	return document.projects.map((project) => {
-		if (!project || typeof project !== 'object' || Array.isArray(project)) throw new Error('Development project selection must be an object.');
-		const input = project as Record<string, unknown>;
-		if (typeof input.manifest !== 'string') throw new Error('Development project selection requires a manifest path.');
-		const manifest = isAbsolute(input.manifest) ? input.manifest : resolve(root, input.manifest);
-		const worktree = typeof input.worktree === 'string' ? (isAbsolute(input.worktree) ? input.worktree : resolve(root, input.worktree)) : dirname(manifest);
-		return { manifest, worktree, ...(Array.isArray(input.targets) ? { targets: input.targets as ProjectSelection['targets'] } : {}) };
-	});
-}
-
-async function localDevelopmentRuntimeSchema(selections: ProjectSelection[], prepare: boolean) {
-	const sdk = selections.find((selection) => {
-		const document = parseYaml(readFileSync(selection.manifest, 'utf8')) as { development?: { project?: { id?: unknown; repository?: unknown } } };
-		return document.development?.project?.id === 'sdk' && document.development.project.repository === 'treeseed-ai/sdk';
-	});
-	if (!sdk) return developmentRuntimeSchema;
-	const worktree = sdk.worktree ?? dirname(sdk.manifest), packagePath = resolve(worktree, 'package.json');
-	const packageDocument = JSON.parse(readFileSync(packagePath, 'utf8')) as { name?: unknown; scripts?: { ['build:dist']?: unknown } };
-	if (packageDocument.name !== '@treeseed/sdk' || typeof packageDocument.scripts?.['build:dist'] !== 'string') throw new Error('The selected SDK source is not a buildable @treeseed/sdk worktree.');
-	if (prepare) {
-		const result = spawnSync('npm', ['run', 'build:dist'], { cwd: worktree, env: process.env, stdio: 'inherit', timeout: 900_000 });
-		if (result.status !== 0) throw new Error('The selected SDK source contract could not be built.');
-	}
-	const entrypoint = resolve(worktree, 'dist/development/index.js');
-	if (!existsSync(entrypoint)) throw new Error('The selected SDK source contract is not built. Run development session start without --plan to prepare it.');
-	const module = await import(`${pathToFileURL(entrypoint).href}?source=${statSync(entrypoint).mtimeMs}`) as { developmentRuntimeSchema?: typeof developmentRuntimeSchema };
-	if (!module.developmentRuntimeSchema?.parse) throw new Error('The selected SDK source does not export its development runtime contract.');
-	return module.developmentRuntimeSchema;
-}
-
-async function loadRuntimes(file: string, prepareLocalSdk = false) {
-	const selections = projectSelections(file), schema = await localDevelopmentRuntimeSchema(selections, prepareLocalSdk);
-	return selections.map((selection) => {
-		const document = parseYaml(readFileSync(selection.manifest, 'utf8')) as { development?: unknown };
-		return { selection, runtime: schema.parse(document.development) };
-	});
-}
 
 function hostCommand(handlerId: string, payload: unknown) {
 	return { handlerId, arguments: [], options: { payload: JSON.stringify(payload) } };
@@ -210,7 +168,7 @@ async function waitForDirectReadiness(target: DevelopmentTarget, timeoutSeconds:
 async function startSession(invocation: ParsedInvocation, context: CommandContext) {
 	const manifest = resolve(context.cwd, invocation.arguments[0]!);
 	if (invocation.options.plan !== true) assertNoSelectedDevelopmentCustody(context.env);
-	const projects = await loadRuntimes(manifest, invocation.options.plan !== true);
+	const projects = await loadDevelopmentRuntimes(manifest, invocation.options.plan !== true);
 	const now = new Date();
 	const sessionId = `dev-${randomUUID().slice(0, 12)}`;
 	const targets = projects.flatMap(({ selection, runtime }) => (selection.targets ?? runtime.targets.map((target) => ({ id: target.id, mode: target.kind === 'rebuild-restart' ? 'candidate' as const : 'released' as const }))).map((target) => ({ projectId: runtime.project.id, targetId: target.id, mode: target.mode, generation: 0, health: target.mode === 'released' ? 'ready' as const : 'pending' as const })));
@@ -494,7 +452,7 @@ async function runDevelopmentUnlocked(invocation: ParsedInvocation, context: Com
 		if (invocation.options.plan === true) return { sessionId, restore: true, mutation: false };
 		const running = await stopProcesses(state);
 		const active = new Set(running.map((entry) => `${entry.projectId}.${entry.targetId}`));
-		for (const { selection, runtime } of await loadRuntimes(state.manifest)) for (const target of runtime.targets) {
+		for (const { selection, runtime } of await loadDevelopmentRuntimes(state.manifest)) for (const target of runtime.targets) {
 			if (usesManagedContainer(target)) await containerOperation(context, sessionId, runtime, target, 'stop');
 			else if (active.has(`${runtime.project.id}.${target.id}`) && target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, selection.worktree!, 'released', context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'session' });
 		}
@@ -505,7 +463,7 @@ async function runDevelopmentUnlocked(invocation: ParsedInvocation, context: Com
 	if (invocation.command.name === 'dev logs') {
 		const selected = typeof invocation.options.target === 'string' ? invocation.options.target : null;
 		const logs: unknown[] = Object.entries(state.processes).filter(([key]) => !selected || key === selected).map(([target, processState]) => ({ target, path: processState.log, bytes: existsSync(processState.log) ? statSync(processState.log).size : 0 }));
-		for (const { runtime } of await loadRuntimes(state.manifest)) for (const target of runtime.targets) {
+		for (const { runtime } of await loadDevelopmentRuntimes(state.manifest)) for (const target of runtime.targets) {
 			const key = `${runtime.project.id}.${target.id}`;
 			if (usesManagedContainer(target) && (!selected || selected === key)) logs.push({ target: key, diagnostics: await containerOperation(context, sessionId, runtime, target, 'logs') });
 		}

--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -194,6 +194,14 @@ async function startSession(invocation: ParsedInvocation, context: CommandContex
 	const leases = projects.flatMap(({ selection, runtime }) => runtime.targets.filter((target) => targets.some((entry) => entry.projectId === runtime.project.id && entry.targetId === target.id && entry.mode !== 'released')).flatMap((target) => target.endpoints.filter((endpoint) => endpoint.canonicalAlias).map((endpoint) => ({ kind: 'alias' as const, resource: endpoint.canonicalAlias!, acquiredAt: now.toISOString() }))));
 	const session = { schemaVersion: 'treeseed.development-session/v2' as const, sessionId, actor: String(invocation.options.actor ?? context.env.USER ?? 'local-developer'), hostId: 'local-host', createdAt: now.toISOString(), status: 'planning' as const, repositories: projects.map(({ selection, runtime }) => repositoryClosure(runtime, selection.worktree!)), targets, leases, restoredReceiptId: null, blockers: [] };
 	if (invocation.options.plan === true) return { session, runtimes: projects.map(({ runtime }) => runtime), mutation: false };
+	const selectedState = statePath(context.env);
+	if (existsSync(selectedState)) {
+		const selected = JSON.parse(readFileSync(selectedState, 'utf8')) as LocalSessionState;
+		const ownsProcesses = Object.values(selected.processes ?? {}).some((entry) => ownsDevelopmentProcess(entry, selected.sessionId));
+		if (ownsProcesses || (selected.overlays ?? []).length > 0) {
+			throw new Error(`Development session ${selected.sessionId} still owns local processes or package overlays; stop or recover it before starting another session.`);
+		}
+	}
 	const result = await invoke(context, 'local.dev.session.start', { session, runtimes: projects.map(({ runtime }) => runtime) });
 	saveState({ sessionId, manifest, processes: {}, overlays: [], candidates: [] }, context.env); return result;
 }

--- a/tests/unit/command-boundary/development-session.test.ts
+++ b/tests/unit/command-boundary/development-session.test.ts
@@ -76,6 +76,21 @@ test('development session start uses one protected manager command and private l
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('development session start refuses existing package-overlay custody before manager mutation', async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-development-')), file = resolve(root, 'treeseed.package.yaml'), output: string[] = [];
+	try {
+		writeFileSync(file, manifest); execFileSync('git', ['init', '-b', 'staging'], { cwd: root }); execFileSync('git', ['add', '.'], { cwd: root });
+		execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.invalid', 'commit', '-m', 'fixture'], { cwd: root });
+		const env = { XDG_STATE_HOME: resolve(root, 'state'), USER: 'tester' };
+		const stateRoot = resolve(env.XDG_STATE_HOME, 'treeseed/development'); mkdirSync(stateRoot, { recursive: true, mode: 0o700 });
+		writeFileSync(resolve(stateRoot, 'current.json'), JSON.stringify({ sessionId: 'dev-existing', manifest: file, processes: {}, overlays: [{ projectId: 'sdk' }], candidates: [] }));
+		let managerCalls = 0;
+		const exit = await runCommandLine(['dev', 'session', 'start', file, '--json'], { cwd: root, env, interactiveUi: false,
+			hostInvoke: async () => { managerCalls += 1; }, write: (value) => output.push(value) });
+		assert.notEqual(exit, 0); assert.equal(managerCalls, 0); assert.match(output.join(''), /still owns local processes or package overlays/);
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('host runtime development planning is local and status uses the protected manager socket', async () => {
 	const output: string[] = [], calls: any[] = [];
 	const hostInvoke = async (input: any) => { calls.push(input); return { generationId: 'installed', status: 'installed' }; };

--- a/tests/unit/command-boundary/recovery/overlay-readoption.test.ts
+++ b/tests/unit/command-boundary/recovery/overlay-readoption.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, symlinkSync, readlinkSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, symlinkSync, readlinkSync, existsSync, unlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import test from 'node:test';
@@ -44,7 +44,7 @@ test('foreign development links and symlinked backups are rejected before mutati
 		const first = resolve(f.consumers[0]!.worktree, 'node_modules/@test/source');
 		rmSync(first, { recursive: true }); symlinkSync(resolve(f.root, 'foreign/current'), first);
 		assert.throws(f.install, /Another development overlay blocks/); assert.equal(f.state.overlays.length, 0);
-		rmSync(first); mkdirSync(first); writeFileSync(resolve(first, 'original'), 'one');
+		unlinkSync(first); mkdirSync(first); writeFileSync(resolve(first, 'original'), 'one');
 		symlinkSync(f.overlay, `${first}.treeseed-release-dev-test`);
 		assert.throws(f.install, /backup is not a release directory/); assert.equal(f.state.overlays.length, 0);
 	} finally { rmSync(f.root, { recursive: true, force: true }); }

--- a/tests/unit/command-boundary/recovery/overlay-readoption.test.ts
+++ b/tests/unit/command-boundary/recovery/overlay-readoption.test.ts
@@ -32,9 +32,29 @@ test('a later foreign backup conflict does not mutate any earlier consumer', () 
 	const f = fixture(); try {
 		const second = resolve(f.consumers[1]!.worktree, 'node_modules/@test/source');
 		symlinkSync(f.overlay, `${second}.treeseed-release-dev-test`);
-		assert.throws(f.install, /Stale development overlay backup/);
+		assert.throws(f.install, /backup is not a release directory/);
 		assert.equal(f.state.overlays.length, 0);
 		assert.ok(existsSync(resolve(f.consumers[0]!.worktree, 'node_modules/@test/source/original')));
 		assert.equal(readlinkSync(`${second}.treeseed-release-dev-test`), f.overlay);
+	} finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('foreign development links and symlinked backups are rejected before mutation', () => {
+	const f = fixture(); try {
+		const first = resolve(f.consumers[0]!.worktree, 'node_modules/@test/source');
+		rmSync(first, { recursive: true }); symlinkSync(resolve(f.root, 'foreign/current'), first);
+		assert.throws(f.install, /Another development overlay blocks/); assert.equal(f.state.overlays.length, 0);
+		rmSync(first); mkdirSync(first); writeFileSync(resolve(first, 'original'), 'one');
+		symlinkSync(f.overlay, `${first}.treeseed-release-dev-test`);
+		assert.throws(f.install, /backup is not a release directory/); assert.equal(f.state.overlays.length, 0);
+	} finally { rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test('restore refuses a symlinked backup without removing the active overlay', () => {
+	const f = fixture(); try {
+		f.install(); const item = f.state.overlays[0]!; rmSync(item.backup!, { recursive: true }); symlinkSync(f.overlay, item.backup!);
+		assert.throws(() => restoreOverlays(f.state, 'source', false), /backup is not a release directory/);
+		assert.equal(resolve(item.link, '..', readlinkSync(item.link)), resolve(f.overlay, 'current'));
+		assert.equal(existsSync(item.link), true);
 	} finally { rmSync(f.root, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
Closes #208.\n\nPrevents overlapping package sessions and nested backup symlinks before any mutation. Restore now accepts only real release directories, and session start fails closed while a selected session owns processes or overlays.\n\nLocal evidence: targeted lifecycle/overlay suite passes. Full Actions are authoritative.