### PR TITLE
Recover unhealthy managed targets without release publication

### DIFF
--- a/src/cli/commands/development-support/lifecycle.ts
+++ b/src/cli/commands/development-support/lifecycle.ts
@@ -47,7 +47,7 @@ export function managedContainerAlreadyReady(value: unknown, sessionId: string, 
         const instances = result.instances as Array<{ sessionId?: unknown; target?: unknown; running?: unknown; health?: unknown }>;
         if (!instances.length || instances.some((item) => item.sessionId !== sessionId || typeof item.target !== 'string'
             || !item.target.endsWith(`.${targetId}`) || item.running !== true || item.health === 'starting' || item.health === 'unhealthy') || result.ready !== true)
-            throw new Error('Managed runtime is not healthy; use dev restart to drain and recover it.');
+            return false;
         return true;
     }
     if (result?.registered !== true || typeof result.state !== 'string') throw new Error('Managed runtime status is invalid.');
@@ -57,6 +57,6 @@ export function managedContainerAlreadyReady(value: unknown, sessionId: string, 
     if (rows.length !== 1 || rows[0]?.Name !== `treeseed-${sessionId}-api-${targetId}`)
         throw new Error('Managed runtime identity is inconsistent; inspect the session before restarting.');
     if (rows[0].State !== 'running' || rows[0].Health !== 'healthy')
-        throw new Error('Managed runtime is not healthy; use dev restart to drain and recover it.');
+        return false;
     return true;
 }

--- a/tests/unit/command-boundary/development/lifecycle.test.ts
+++ b/tests/unit/command-boundary/development/lifecycle.test.ts
@@ -82,12 +82,12 @@ test('healthy exact managed snapshot is reusable; missing runtime requires start
 test('healthy multi-container manager runtime is reusable', () => {
 	const instances = ['manager', 'runner'].map((name) => ({ name, sessionId: 'dev-test', target: 'agent.provider', running: true, health: 'healthy' }));
 	assert.equal(managedContainerAlreadyReady({ registered: true, instances, ready: true }, 'dev-test', 'provider'), true);
-	assert.throws(() => managedContainerAlreadyReady({ registered: true, instances: [{ ...instances[0], running: false }], ready: false }, 'dev-test', 'provider'), /not healthy/);
+	assert.equal(managedContainerAlreadyReady({ registered: true, instances: [{ ...instances[0], running: false }], ready: false }, 'dev-test', 'provider'), false);
 });
 
 test('registered unhealthy, malformed, or wrong-instance state never authorizes overwrite', () => {
     const value = { Name: 'treeseed-dev-test-api-operations-runner', State: 'running', Health: 'unhealthy' };
-    assert.throws(() => managedContainerAlreadyReady({ registered: true, state: JSON.stringify(value) }, 'dev-test', 'operations-runner'), /dev restart/);
+    assert.equal(managedContainerAlreadyReady({ registered: true, state: JSON.stringify(value) }, 'dev-test', 'operations-runner'), false);
     value.Health = 'healthy'; value.Name = 'unrelated';
     assert.throws(() => managedContainerAlreadyReady({ registered: true, state: JSON.stringify(value) }, 'dev-test', 'operations-runner'), /identity/);
     for (const state of ['', 'not json', '{}\n{}']) assert.throws(() => managedContainerAlreadyReady({ registered: true, state }, 'dev-test', 'service'));


### PR DESCRIPTION
Refs #204\n\n## Outcome\nA repeated dev use now rebuilds/recreates a registered but unhealthy managed target instead of directing operators into a restart command that refuses released targets. Identity mismatches and malformed status remain fail-closed.\n\n## Verification\n- complete CLI test suite: 180 passed\n- npm run build\n- live source watcher rebuilt the active CLI overlay\n- repeated AI use reached manager activation and retained MODULE_NOT_FOUND diagnostics\n\nNo release is published.