### PR TITLE
Stop only targets owned by a development session

### DIFF
--- a/src/cli/commands/development.ts
+++ b/src/cli/commands/development.ts
@@ -35,10 +35,10 @@ interface DevelopmentStatusRecord {
 	runtimes: DevelopmentRuntime[];
 }
 function statePath(env: NodeJS.ProcessEnv) { return resolve(developmentStateRoot(env), 'current.json'); }
-function saveState(state: LocalSessionState, env: NodeJS.ProcessEnv) {
+function saveState(state: LocalSessionState, env: NodeJS.ProcessEnv, select = true) {
 	const path = statePath(env), temporary = `${path}.new`;
 	mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-	writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 }); renameSync(temporary, path);
+	if (select) { writeFileSync(temporary, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 }); renameSync(temporary, path); }
 	const snapshot=resolve(developmentStateRoot(env),state.sessionId,'session.json');
 	mkdirSync(dirname(snapshot),{recursive:true,mode:0o700});
 	writeFileSync(`${snapshot}.new`,`${JSON.stringify(state,null,2)}\n`,{mode:0o600});renameSync(`${snapshot}.new`,snapshot);
@@ -450,13 +450,20 @@ async function runDevelopmentUnlocked(invocation: ParsedInvocation, context: Com
 	const state = loadState(context.env,invocation.options.session), sessionId = String(invocation.options.session ?? state.sessionId);
 	if (invocation.command.name === 'dev session stop') {
 		if (invocation.options.plan === true) return { sessionId, restore: true, mutation: false };
+		const isSelected = JSON.parse(readFileSync(statePath(context.env), 'utf8')).sessionId === sessionId;
+		const record = await invoke(context, 'local.dev.status', { sessionId, all: false }) as DevelopmentStatusRecord;
 		const running = await stopProcesses(state);
 		const active = new Set(running.map((entry) => `${entry.projectId}.${entry.targetId}`));
-		for (const { selection, runtime } of await loadDevelopmentRuntimes(state.manifest)) for (const target of runtime.targets) {
-			if (usesManagedContainer(target)) await containerOperation(context, sessionId, runtime, target, 'stop');
-			else if (active.has(`${runtime.project.id}.${target.id}`) && target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, selection.worktree!, 'released', context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'session' });
+		for (const selected of record.session.targets) {
+			const { runtime, target } = selectedTarget(record, selected.projectId, selected.targetId);
+			const repository = record.session.repositories.find((entry) => entry.projectId === selected.projectId);
+			if (usesManagedContainer(target)) {
+				const status = await containerOperation(context, sessionId, runtime, target, 'status') as { registered?: unknown };
+				if (status.registered === true) await containerOperation(context, sessionId, runtime, target, 'stop');
+			}
+			else if (repository && active.has(`${runtime.project.id}.${target.id}`) && target.operations.cleanup) runOneShotOperation(state, target.operations.cleanup, repository.worktree, 'released', context.env, { TREESEED_DEVELOPMENT_CLEANUP_SCOPE: 'session' });
 		}
-		restoreOverlays(state); selectDevelopmentCli(context.env, null); saveState(state, context.env); return invoke(context, 'local.dev.session.stop', { sessionId });
+		restoreOverlays(state); if (isSelected) selectDevelopmentCli(context.env, null); saveState(state, context.env, isSelected); return invoke(context, 'local.dev.session.stop', { sessionId });
 	}
 	if (invocation.command.name === 'dev status') return invoke(context, 'local.dev.status', { ...(invocation.options.session ? { sessionId } : {}), all: invocation.options.all === true });
 	if (invocation.command.name === 'dev plan') return invoke(context, 'local.dev.plan', { sessionId, selected: [] });

--- a/tests/unit/command-boundary/development-session.test.ts
+++ b/tests/unit/command-boundary/development-session.test.ts
@@ -91,6 +91,29 @@ test('development session start refuses existing package-overlay custody before 
 	} finally { rmSync(root, { recursive: true, force: true }); }
 });
 
+test('stopping another session preserves the selected session and skips unregistered managed targets', async () => {
+	const root = mkdtempSync(resolve(tmpdir(), 'treeseed-cli-development-stop-'));
+	try {
+		const env = { XDG_STATE_HOME: resolve(root, 'state'), USER: 'tester' }, stateRoot = resolve(root, 'state/treeseed/development');
+		const current = { sessionId: 'dev-current', manifest: '/current.yaml', processes: {}, overlays: [], candidates: [] };
+		const stale = { sessionId: 'dev-stale', manifest: '/missing.yaml', processes: {}, overlays: [], candidates: [] };
+		mkdirSync(stateRoot, { recursive: true, mode: 0o700 }); mkdirSync(resolve(stateRoot, 'dev-stale'), { mode: 0o700 });
+		writeFileSync(resolve(stateRoot, 'current.json'), JSON.stringify(current));
+		writeFileSync(resolve(stateRoot, 'dev-stale/session.json'), JSON.stringify(stale));
+		const target = { id: 'service', kind: 'live-api', executionCustody: 'manager', operations: {}, endpoints: [] };
+		const record = { session: { sessionId: 'dev-stale', status: 'active', repositories: [{ projectId: 'api', worktree: '/workspace/api' }], targets: [{ projectId: 'api', targetId: 'service', mode: 'released' }] }, runtimes: [{ project: { id: 'api' }, targets: [target] }] };
+		const calls: Array<{ handlerId: string; options: { payload?: string } }> = [], output: string[] = [];
+		const exit = await runCommandLine(['dev', 'session', 'stop', '--session', 'dev-stale', '--json'], { env, interactiveUi: false,
+			hostInvoke: async (input) => { calls.push(input as typeof calls[number]); if (input.handlerId === 'local.dev.status') return record;
+				if (input.handlerId === 'local.dev.container') return { registered: false, state: null }; return { session: { sessionId: 'dev-stale', status: 'stopped' } }; },
+			write: (value) => output.push(value) });
+		assert.equal(exit, 0, output.join('\n'));
+		assert.equal(JSON.parse(readFileSync(resolve(stateRoot, 'current.json'), 'utf8')).sessionId, 'dev-current');
+		const containerCalls = calls.filter((call) => call.handlerId === 'local.dev.container').map((call) => JSON.parse(String(call.options.payload)));
+		assert.deepEqual(containerCalls, [{ sessionId: 'dev-stale', projectId: 'api', targetId: 'service', action: 'status' }]);
+	} finally { rmSync(root, { recursive: true, force: true }); }
+});
+
 test('host runtime development planning is local and status uses the protected manager socket', async () => {
 	const output: string[] = [], calls: any[] = [];
 	const hostInvoke = async (input: any) => { calls.push(input); return { generationId: 'installed', status: 'installed' }; };

--- a/tests/unit/command-boundary/host/managed-development-container.test.ts
+++ b/tests/unit/command-boundary/host/managed-development-container.test.ts
@@ -42,6 +42,6 @@ test('container startup and cleanup only invoke the protected manager, including
     assert.equal(await runCommandLine(['dev','restart','api.service','--session',selected,'--json'],context),0);
     assert.equal(await runCommandLine(['dev','use','api.service=released','--session',selected,'--json'],context),0);
     assert.equal(await runCommandLine(['dev','session','stop','--session',selected,'--json'],context),0);
-    assert.deepEqual(actions,['status','start','stop','start','stop','stop']);
+    assert.deepEqual(actions,['status','start','stop','start','stop','status']);
   } finally {rmSync(root,{recursive:true,force:true});}
 });


### PR DESCRIPTION
Closes #202

## Outcome
- stops only manager-registered targets owned by the selected session
- preserves an independently selected live CLI session when another session stops
- cleans the registered worktree rather than stale manifest paths
- adds regression coverage for unregistered targets and selection preservation

## Verification
- `npm test` — 181 passed
- targeted development-session and managed-container tests — 14 passed